### PR TITLE
Add looping video background to the OpenGL renderer

### DIFF
--- a/gui/background_filepicker_frame.py
+++ b/gui/background_filepicker_frame.py
@@ -37,7 +37,7 @@ class BackgroundFilepickerFrame(ctk.CTkFrame):
         self.apply_button.grid(row=2, column=0, columnspan=2, sticky="EW", padx=5, pady=5)
 
     def open_file_dialog(self) -> None:
-        self._filename = filedialog.askopenfilename(initialdir = "./resources/bg", title = "Select a File", filetypes = (("Image files", "*.png;*.jpg;*.jpeg;*.gif"), ("all files", "*.*")))
+        self._filename = filedialog.askopenfilename(initialdir = "./resources/bg", title = "Select a File", filetypes = (("Image files", "*.png;*.jpg;*.jpeg;*.gif"), ("Video files", "*.mp4;*.avi;*.mov;*.mkv"), ("all files", "*.*")))
         if self._filename:
             self.image_path_entry.delete(0, ctk.END)
             self.image_path_entry.insert(0, self._filename)

--- a/gui/main_window_gui.py
+++ b/gui/main_window_gui.py
@@ -1,3 +1,4 @@
+import os
 import queue
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
@@ -31,6 +32,8 @@ from resource_manager import ResourceManager
 # tenendo solo l'audio più recente, quindi una coda corta evita backlog/latenza.
 MAX_QUEUE_SIZE = 8
 INITIAL_FREQUENCIES_BANDS = 9
+# Estensioni trattate come video (sfondo animato, solo renderer OpenGL).
+VIDEO_EXTENSIONS = ('.mp4', '.avi', '.mov', '.mkv')
 RESIZE_DEBOUNCE_MS = 500
 DOUBLE_LEFT_MOUSE_BUTTON_CLICK = '<Double-Button-1>'
 CLOSE_WINDOW_EVENT = 'WM_DELETE_WINDOW'
@@ -56,6 +59,7 @@ class AudioCaptureGUI(ctk.CTk):
         self.devices = []
         self.canvas_width = self.canvas_height = None
         self.bg_alpha = 0.5
+        self.bg_video_path = None  # path del video di sfondo selezionato (None = immagine)
         self.selected_monitor = None
         self.available_monitors = self.get_available_monitors()
 
@@ -213,11 +217,9 @@ class AudioCaptureGUI(ctk.CTk):
 
     def apply_bg_command(self):
         """
-        Applica l'immagine di sfondo selezionata all'equalizzatore.
-
-        Raises:
-            FileNotFoundError: Se il file non esiste
-            PIL.UnidentifiedImageError: Se il file non è un'immagine valida
+        Applica lo sfondo selezionato (immagine o video) all'equalizzatore.
+        Discrimina per estensione: i video sono gestiti SOLO dal renderer OpenGL
+        (fullscreen); la preview Tkinter mostra un segnaposto testuale.
         """
         filename = self.file_picker.get_filename()
         if not filename:
@@ -228,7 +230,23 @@ class AudioCaptureGUI(ctk.CTk):
             )
             return
 
+        ext = os.path.splitext(filename)[1].lower()
+        if ext in VIDEO_EXTENSIONS:
+            self._apply_video_background(filename)
+        else:
+            self._apply_image_background(filename)
+
+    def _apply_image_background(self, filename: str):
+        """
+        Carica un'immagine come sfondo: aggiorna la preview Tkinter e inoltra
+        l'immagine al renderer OpenGL (set_image, che ferma un eventuale video).
+
+        Raises:
+            FileNotFoundError: Se il file non esiste
+            PIL.UnidentifiedImageError: Se il file non è un'immagine valida
+        """
         try:
+            self.bg_video_path = None  # torna alla modalità immagine
             self.bg_img = Image.open(filename)
             self.bg_img_used = self.bg_img.copy()
             self.bg_img_used.putalpha(int(255 * self.bg_alpha))
@@ -246,6 +264,44 @@ class AudioCaptureGUI(ctk.CTk):
                 message=f'Errore nel caricamento dell\'immagine: {str(e)}',
                 icon="error"
             )
+
+    def _apply_video_background(self, filename: str):
+        """
+        Seleziona un video come sfondo (feature solo-OpenGL). La preview Tkinter
+        non riproduce il video: mostra un segnaposto. Se il fullscreen è già aperto
+        il video parte subito (set_video); altrimenti partirà all'apertura del
+        fullscreen (bg_video passato al costruttore del thread OpenGL).
+        """
+        if not os.path.isfile(filename):
+            CTkMessagebox(
+                title='Errore',
+                message='File non trovato!',
+                icon="error"
+            )
+            return
+        self.bg_video_path = filename
+        self._show_video_placeholder()
+        self.update_video_opengl(filename)
+
+    def _show_video_placeholder(self):
+        """
+        Mostra un segnaposto testuale sul canvas in-window al posto dell'immagine:
+        la riproduzione del video avviene solo nel renderer OpenGL fullscreen.
+        """
+        self.equalizer_canvas.delete('background')
+        self.equalizer_canvas.delete('placeholder')
+        self.equalizer_canvas.update_idletasks()
+        w = max(self.equalizer_canvas.winfo_width(), 1)
+        h = max(self.equalizer_canvas.winfo_height(), 1)
+        self.equalizer_canvas.create_text(
+            w // 2, h // 2,
+            text='Video di sfondo attivo\n(visibile in modalità Fullscreen)',
+            fill='#FFFFFF',
+            font=("Roboto", 16, "bold"),
+            justify=tk.CENTER,
+            tags='placeholder'
+        )
+        self.equalizer_canvas.tag_lower('placeholder')
 
     def _build_settings_tabs(self, parent):
         """
@@ -281,8 +337,8 @@ class AudioCaptureGUI(ctk.CTk):
         # Immagine di sfondo
         self.file_picker = BackgroundFilepickerFrame(
             vis_tab,
-            header_name='Immagine di Sfondo:',
-            placeholder_text='Percorso immagine...',
+            header_name='Sfondo (immagine o video):',
+            placeholder_text='Percorso file...',
             apply_command=self.apply_bg_command
         )
         self.file_picker.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
@@ -338,6 +394,8 @@ class AudioCaptureGUI(ctk.CTk):
         self.frequency_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
 
     def apply_background(self):
+        # Rimuovi un eventuale segnaposto video: stiamo tornando a un'immagine.
+        self.equalizer_canvas.delete('placeholder')
         self.equalizer_canvas.update_idletasks()
         self.canvas_width, self.canvas_height = self.equalizer_canvas.winfo_width(), self.equalizer_canvas.winfo_height()
         if self.canvas_height != self.bg_img_used.height or self.canvas_width != self.bg_img_used.width:
@@ -449,12 +507,24 @@ class AudioCaptureGUI(ctk.CTk):
             }
             self.equalizer_control_queue.put(message)
 
+    def update_video_opengl(self, path: str):
+        if self.equalizer_opengl_thread:
+            message = {
+                "type": "set_video",
+                "value": path
+            }
+            self.equalizer_control_queue.put(message)
+
     def update_alpha(self, value):
         self.bg_alpha = value
-        self.bg_img_used.putalpha(int(255 * self.bg_alpha))
-        self.canvas_image = ImageTk.PhotoImage(self.bg_img_used)
-        self.equalizer_canvas.create_image(0, 0, anchor=ctk.NW, image=self.canvas_image, tags='background')
-        self.equalizer_canvas.tag_lower('background')
+        # In modalità video la preview in-window mostra il segnaposto, non
+        # l'immagine: evita di ridisegnare lo sfondo. L'alpha vale comunque per il
+        # video, inoltrato al renderer OpenGL (uniform uAlpha).
+        if self.bg_video_path is None:
+            self.bg_img_used.putalpha(int(255 * self.bg_alpha))
+            self.canvas_image = ImageTk.PhotoImage(self.bg_img_used)
+            self.equalizer_canvas.create_image(0, 0, anchor=ctk.NW, image=self.canvas_image, tags='background')
+            self.equalizer_canvas.tag_lower('background')
 
         # send msg to opengl window if active
         self.update_alpha_opengl(value)
@@ -588,6 +658,8 @@ class AudioCaptureGUI(ctk.CTk):
                     n_bands=int(self.frequency_slider.get_value()),
                     control_queue=self.equalizer_control_queue,
                     bg_image=self.bg_img,
+                    bg_alpha=self.bg_alpha,
+                    bg_video=self.bg_video_path,
                     monitor=self.selected_monitor,
                     window_close_callback=self.opengl_window_closed
                 )
@@ -618,6 +690,11 @@ class AudioCaptureGUI(ctk.CTk):
 
     def resize_background(self, canvas: tk.Canvas):
         self.canvas_width, self.canvas_height = canvas.winfo_width(), canvas.winfo_height()
+        # In modalità video la preview mostra il segnaposto: riposizionalo e basta.
+        if self.bg_video_path is not None:
+            self._show_video_placeholder()
+            self.resize_scheduled = False
+            return
         # Resize the image using the resize() method starting from the original image
         self.bg_img_used = self.bg_img.resize((self.canvas_width, self.canvas_height), reducing_gap=2.0).copy()
         self.bg_img_used.putalpha(int(255 * self.bg_alpha))

--- a/py-to-exe-settings.json
+++ b/py-to-exe-settings.json
@@ -68,6 +68,22 @@
   {
    "optionDest": "datas",
    "value": "C:/Users/Claudio/PycharmProjects/easy-graphic-equalizer/glfw3.dll;."
+  },
+  {
+   "optionDest": "collect_all",
+   "value": "imageio_ffmpeg"
+  },
+  {
+   "optionDest": "hiddenimports",
+   "value": "imageio"
+  },
+  {
+   "optionDest": "hiddenimports",
+   "value": "imageio_ffmpeg"
+  },
+  {
+   "optionDest": "hiddenimports",
+   "value": "imageio.plugins.ffmpeg"
   }
  ],
  "nonPyinstallerOptions": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,6 @@ dependencies = [
     "PyOpenGL",
     "PyOpenGL-accelerate",
     "glfw",
+    "imageio>=2.37.3",
+    "imageio-ffmpeg>=0.6.0",
 ]

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -13,6 +13,7 @@ from PIL import Image
 from PIL.Image import Transpose
 
 from thread.AudioBufferAccumulator import AudioBufferAccumulator
+from thread.video_decode_thread import VideoDecodeThread
 
 RATE = 44100
 N_FFT = 4096
@@ -37,6 +38,11 @@ TILT_DB_PER_OCT = 0.0
 BAR_WIDTH_FRAC = 0.8    # frazione dello slot occupata dalla barra (il resto è spazio)
 GREEN_SPLIT = 0.5       # sotto questa frazione d'altezza finestra → verde
 YELLOW_SPLIT = 0.8      # tra GREEN_SPLIT e questa → giallo; oltre → rosso
+
+# --- Video di sfondo (solo OpenGL) ---
+# Massimo numero di frame video "recuperabili" in un singolo tick di rendering:
+# evita che, dopo uno stallo (resize, breakpoint), il video parta in fast-forward.
+MAX_CATCHUP_FRAMES = 4
 
 # --- Shader GLSL (OpenGL 3.3 core) ---
 # Barre: rendering instanced. Il quad unitario [0,1]² viene espanso per ogni barra
@@ -77,13 +83,17 @@ void main() {
 
 # Sfondo: quad fullscreen testurizzato. L'alpha è una uniform → nessuna ricreazione
 # della texture quando cambia (niente più re-upload né leak).
+# uFlipV capovolge la coordinata v a costo zero: le immagini sono già flippate in CPU
+# da load_texture (uFlipV=0), mentre i frame video hanno la riga 0 in alto e vanno
+# capovolti qui (uFlipV=1) invece di copiarli flippati a ogni frame.
 _BG_VERTEX_SRC = """
 #version 330 core
 layout(location = 0) in vec2 aPos;        // NDC [-1,1]
 layout(location = 1) in vec2 aTexCoord;
+uniform float uFlipV;                     // 0 = immagine (già flippata), 1 = frame video
 out vec2 vTexCoord;
 void main() {
-    vTexCoord = aTexCoord;
+    vTexCoord = vec2(aTexCoord.x, mix(aTexCoord.y, 1.0 - aTexCoord.y, uFlipV));
     gl_Position = vec4(aPos, 0.0, 1.0);
 }
 """
@@ -134,6 +144,7 @@ class EqualizerOpenGLThread(threading.Thread):
                  monitor=None,
                  bg_image: Optional[Image.Image] = None,
                  bg_alpha: Optional[float] = None,
+                 bg_video: Optional[str] = None,
                  window_close_callback: Callable = None):
         super().__init__()
         self._audio_queue = audio_queue
@@ -160,6 +171,16 @@ class EqualizerOpenGLThread(threading.Thread):
 
         self.stop_event = threading.Event()
         self._background_texture = None
+
+        # --- Stato video di sfondo (solo OpenGL): vedi _start_video/_advance_video ---
+        self._bg_video = bg_video           # path video iniziale (opzionale)
+        self._video_thread = None           # VideoDecodeThread produttore di frame (CPU)
+        self._video_queue = None            # coda corta dei frame decodificati
+        self._video_texture = None          # texture GL dedicata al video (separata dall'immagine)
+        self._video_active = False          # True quando il video sostituisce l'immagine
+        self._video_tex_size = None         # (w, h) texture allocata; None = non ancora creata
+        self._video_frame_interval = 1.0 / 30.0  # 1/fps (aggiornato dai metadati del video)
+        self._video_time_acc = 0.0          # accumulatore di tempo per il pacing del video
 
         self.window_width = self.window_height = None
         self.frame_rate = None
@@ -331,7 +352,7 @@ class EqualizerOpenGLThread(threading.Thread):
         }
         self._bg_uniforms = {
             name: glGetUniformLocation(self._bg_program, name)
-            for name in ("uTexture", "uAlpha")
+            for name in ("uTexture", "uAlpha", "uFlipV")
         }
 
         # --- VAO/VBO barre ---
@@ -409,14 +430,25 @@ class EqualizerOpenGLThread(threading.Thread):
         if num_bars < 1:
             return
 
-        # --- Sfondo ---
-        if self._background_texture:
+        # --- Sfondo: video se attivo e pronto, altrimenti immagine. Stesso shader.
+        #     uFlipV=1 per il video (riga 0 in alto), 0 per l'immagine (già flippata).
+        #     Finché il primo frame video non è pronto si mostra l'ultima immagine
+        #     (transizione morbida, niente flash nero).
+        if self._video_active and self._video_texture:
+            bg_tex, flip = self._video_texture, 1.0
+        elif self._background_texture:
+            bg_tex, flip = self._background_texture, 0.0
+        else:
+            bg_tex, flip = None, 0.0
+
+        if bg_tex:
             glUseProgram(self._bg_program)
             alpha = 1.0 if self._bg_alpha is None else float(self._bg_alpha)
             glActiveTexture(GL_TEXTURE0)
-            glBindTexture(GL_TEXTURE_2D, self._background_texture)
+            glBindTexture(GL_TEXTURE_2D, bg_tex)
             glUniform1i(self._bg_uniforms["uTexture"], 0)
             glUniform1f(self._bg_uniforms["uAlpha"], alpha)
+            glUniform1f(self._bg_uniforms["uFlipV"], flip)
             glBindVertexArray(self._bg_vao)
             glDrawArrays(GL_TRIANGLES, 0, 6)
 
@@ -451,6 +483,9 @@ class EqualizerOpenGLThread(threading.Thread):
         if self._background_texture:
             _safe(lambda: glDeleteTextures(1, [self._background_texture]))
             self._background_texture = None
+        if self._video_texture:
+            _safe(lambda: glDeleteTextures(1, [self._video_texture]))
+            self._video_texture = None
         for vbo in (self._bars_quad_vbo, self._heights_vbo, self._bg_vbo):
             if vbo:
                 _safe(lambda v=vbo: glDeleteBuffers(1, [v]))
@@ -490,7 +525,18 @@ class EqualizerOpenGLThread(threading.Thread):
             self._bg_alpha = message['value']
 
         elif message_type == 'set_image':
+            # L'immagine sostituisce il video: ferma l'eventuale riproduzione.
+            self._stop_video()
             self._bg_image = message['value']
+            self._background_texture = self.load_texture()
+
+        elif message_type == 'set_video':
+            # value = path del file video (stringa). Il decoder vive sul suo thread.
+            self._start_video(message['value'])
+
+        elif message_type == 'clear_video':
+            # Torna all'immagine di sfondo (se presente).
+            self._stop_video()
             self._background_texture = self.load_texture()
 
     def smooth_amplitudes(self, targets, delta_time: float) -> np.ndarray:
@@ -594,6 +640,10 @@ class EqualizerOpenGLThread(threading.Thread):
             self.init_gl_objects()
             self._background_texture = self.load_texture()
 
+            # Se è stato richiesto un video di sfondo all'avvio, avvialo subito.
+            if self._bg_video:
+                self._start_video(self._bg_video)
+
             # Timing preciso
             last_frame_time = glfw.get_time()
 
@@ -638,6 +688,11 @@ class EqualizerOpenGLThread(threading.Thread):
                 # 3) Ballistica attacco/rilascio
                 smoothed_amplitudes = self.smooth_amplitudes(self.target_amplitudes, frame_delta)
 
+                # 3.5) Avanza il video di sfondo (se attivo) e aggiorna la sua texture.
+                #      Pacing disaccoppiato dal refresh: vedi _advance_video.
+                if self._video_active:
+                    self._advance_video(frame_delta)
+
                 # 4) Disegna il frame (sfondo + barre instanced) con i valori smoothed
                 self._render(smoothed_amplitudes)
 
@@ -654,6 +709,8 @@ class EqualizerOpenGLThread(threading.Thread):
             if self.window_close_callback:
                 self.window_close_callback()
         finally:
+            # Ferma il decoder video e il subprocess ffmpeg prima di liberare il GL.
+            self._stop_video()
             # Cleanup garantito: risorse GL, finestra e GLFW (sicuro anche su init parziale).
             self._cleanup_gl()
             if window is not None:
@@ -714,6 +771,131 @@ class EqualizerOpenGLThread(threading.Thread):
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
                      GL_UNSIGNED_BYTE, im_data)
         return texture
+
+    # ------------------------------------------------------------------
+    # Video di sfondo (solo OpenGL). La DECODIFICA (CPU) gira su un thread
+    # dedicato (VideoDecodeThread); QUI, sul thread OpenGL, avviene solo
+    # l'UPLOAD GPU della texture, dove il contesto GL è valido.
+    # ------------------------------------------------------------------
+    def _start_video(self, path: str) -> None:
+        """
+        Avvia (o riavvia) la riproduzione del video di sfondo: ferma un eventuale
+        video in corso, crea la coda dei frame e il thread decoder, e attiva la
+        modalità video. La texture video è allocata pigramente al primo frame
+        (in _upload_video_frame). L'immagine corrente resta visibile finché il
+        primo frame non è pronto. Da chiamare sul thread OpenGL.
+        """
+        self._stop_video()
+        if not path:
+            return
+        self._video_queue = queue.Queue(maxsize=2)
+        self._video_thread = VideoDecodeThread(path, self._video_queue)
+        self._video_thread.start()
+        self._video_tex_size = None
+        self._video_time_acc = 0.0
+        self._video_frame_interval = 1.0 / 30.0
+        self._video_active = True
+
+    def _stop_video(self) -> None:
+        """
+        Ferma il thread decoder (se attivo), svuota la coda dei frame e libera la
+        texture video. Idempotente e centralizzato: usato da set_video (cambio
+        video), clear_video, set_image e dal finally di run(). Richiede un contesto
+        GL valido per glDeleteTextures (tutti i chiamanti girano sul thread GL).
+        """
+        if self._video_thread is not None:
+            self._video_thread.stop()
+            self._video_thread.join(timeout=1.0)
+            self._video_thread = None
+        self._video_queue = None
+        self._video_active = False
+        self._video_tex_size = None
+        self._video_time_acc = 0.0
+        if self._video_texture:
+            try:
+                glDeleteTextures(1, [self._video_texture])
+            except Exception:
+                pass
+            self._video_texture = None
+
+    def _advance_video(self, frame_delta: float) -> None:
+        """
+        Fa avanzare il video in modo indipendente dal refresh del monitor: accumula
+        il tempo trascorso e consuma dalla coda ESATTAMENTE il numero di frame che il
+        tempo concede (uno per intervallo-frame del video), mostrando l'ultimo dei
+        frame consumati. Così il decoder — che si blocca sul put a coda piena — va in
+        back-pressure alla velocità REALE del video. NON si drena tutta la coda (lo
+        facevamo come per l'audio, ma il decoder produce più veloce del realtime →
+        scartando i frame pronti il video accelerava). Se la coda è vuota mantiene il
+        frame già visualizzato. Il pacing è disaccoppiato dall'FFT/dalle barre.
+
+        Args:
+            frame_delta (float): secondi trascorsi dall'ultimo frame di rendering.
+        """
+        if not self._video_active or self._video_queue is None:
+            return
+
+        # fps letto live dal thread decoder (default finché i metadati non sono pronti).
+        if self._video_thread is not None and self._video_thread.fps > 0:
+            self._video_frame_interval = 1.0 / self._video_thread.fps
+
+        self._video_time_acc += frame_delta
+        if self._video_time_acc < self._video_frame_interval:
+            return  # non è ancora ora del prossimo frame: riusa la texture corrente
+
+        # Numero di frame "dovuti" dato il tempo accumulato; clamp anti-fast-forward
+        # dopo uno stallo abnorme (resize/breakpoint), altrimenti sottrai con precisione.
+        steps = int(self._video_time_acc / self._video_frame_interval)
+        if steps > MAX_CATCHUP_FRAMES:
+            steps = MAX_CATCHUP_FRAMES
+            self._video_time_acc = 0.0
+        else:
+            self._video_time_acc -= steps * self._video_frame_interval
+
+        # Consuma ESATTAMENTE `steps` frame e mostra l'ultimo: a refresh > fps si avanza
+        # di 1 frame per intervallo (gli altri tick riusano la texture); a refresh < fps
+        # si saltano i frame in eccesso. NON drenare tutta la coda: il decoder corre più
+        # veloce del realtime e scartarne i frame pronti accelererebbe il video.
+        frame = None
+        for _ in range(steps):
+            try:
+                frame = self._video_queue.get_nowait()
+            except queue.Empty:
+                break
+
+        if frame is not None:
+            self._upload_video_frame(frame)
+
+    def _upload_video_frame(self, frame: np.ndarray) -> None:
+        """
+        Carica un frame video (np.ndarray HxWx3 uint8 RGB, riga 0 in alto) nella
+        texture video. Alloca con glTexImage2D al primo frame o quando cambiano le
+        dimensioni, poi aggiorna in-place con glTexSubImage2D (niente riallocazioni).
+        Il flip verticale è demandato allo shader (uFlipV=1), non copiato in CPU.
+        """
+        h, w = int(frame.shape[0]), int(frame.shape[1])
+
+        # Frame RGB a 3 byte/pixel: con larghezza non multipla di 4 l'allineamento
+        # di default (4) sfalserebbe le righe. Forziamo l'allineamento a 1 byte.
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+
+        if self._video_texture is None:
+            self._video_texture = glGenTextures(1)
+            glBindTexture(GL_TEXTURE_2D, self._video_texture)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+            self._video_tex_size = None
+
+        glBindTexture(GL_TEXTURE_2D, self._video_texture)
+        if self._video_tex_size != (w, h):
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB,
+                         GL_UNSIGNED_BYTE, frame)
+            self._video_tex_size = (w, h)
+        else:
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGB,
+                            GL_UNSIGNED_BYTE, frame)
 
     # Il rendering è ora interamente in _render() (shader + instancing, core 3.3):
     # i vecchi draw_background/draw_bars (pipeline fixed-function) sono stati rimossi.

--- a/thread/video_decode_thread.py
+++ b/thread/video_decode_thread.py
@@ -1,0 +1,95 @@
+import threading
+import queue
+from typing import Optional
+
+import numpy as np
+import imageio.v2 as imageio
+
+
+class VideoDecodeThread(threading.Thread):
+    """
+    Thread produttore che decodifica i frame di un video in loop e li pubblica in
+    una coda, modellato sul pattern produttore/consumer di AudioCaptureThread.
+
+    La decodifica (CPU, via backend ffmpeg di imageio) gira QUI; l'upload della
+    texture GPU resta sul thread OpenGL, dove il contesto GL è valido. La coda è
+    volutamente corta (maxsize piccolo): il consumer drena e tiene solo il frame
+    più fresco, quindi non serve accumulare backlog (stessa filosofia dell'audio).
+
+    Ogni frame pubblicato è un np.ndarray di shape (H, W, 3), dtype uint8, in
+    ordine RGB con la riga 0 in alto (il flip verticale per OpenGL è gestito dallo
+    shader di sfondo via uniform uFlipV, non qui).
+
+    Attributes:
+        fps: frame rate del video letto dai metadati (default 30.0 finché ignoto).
+             Letto live dal thread OpenGL per temporizzare l'avanzamento.
+    """
+
+    def __init__(self, path: str, frame_queue: queue.Queue, debug: bool = False):
+        super().__init__(daemon=True)
+        self._path = path
+        self._frame_queue = frame_queue
+        self._debug = debug
+        self.stop_event = threading.Event()
+        # Default prudente finché non leggiamo i metadati reali del video.
+        self.fps = 30.0
+        if self._debug:
+            print(f"Video decode thread created for {path}")
+
+    def run(self):
+        """
+        Apre il video e ne pubblica i frame in loop infinito (riavvolgendo a fine
+        file) finché stop_event non è impostato. Il reader viene SEMPRE chiuso nel
+        finally per rilasciare il subprocess ffmpeg (niente processi orfani).
+        """
+        if self._debug:
+            print("Video decode thread run() called")
+        try:
+            while not self.stop_event.is_set():
+                reader = imageio.get_reader(self._path)
+                try:
+                    meta = reader.get_meta_data()
+                    fps = meta.get('fps')
+                    if fps and fps > 0:
+                        self.fps = float(fps)
+                    if self._debug:
+                        print(f"Video fps={self.fps}, meta={meta}")
+
+                    for frame in reader:
+                        if self.stop_event.is_set():
+                            break
+                        # imageio/ffmpeg restituisce già RGB uint8; garantiamo
+                        # contiguità per un upload GL diretto (glTexImage2D).
+                        if frame.dtype != np.uint8 or not frame.flags["C_CONTIGUOUS"]:
+                            frame = np.ascontiguousarray(frame, dtype=np.uint8)
+                        self._put_frame(frame)
+                finally:
+                    try:
+                        reader.close()
+                    except Exception:
+                        pass
+                # Fine stream: il while esterno ricrea il reader e riparte (loop).
+        except Exception as exc:
+            # Path/codec non leggibile o errore di decodifica: termina il thread
+            # senza far cadere l'app (il renderer continua senza sfondo video).
+            print(f"Video decode thread error: {exc}")
+
+        if self._debug:
+            print("Video decode loop exited")
+
+    def _put_frame(self, frame: np.ndarray) -> None:
+        """
+        Inserisce un frame nella coda bloccando se piena, ma restando reattivo allo
+        stop: il pacing temporale (a quale velocità consumare) è interamente sul
+        lato OpenGL, qui ci limitiamo a riempire quando c'è posto.
+        """
+        while not self.stop_event.is_set():
+            try:
+                self._frame_queue.put(frame, timeout=0.1)
+                return
+            except queue.Full:
+                continue
+
+    def stop(self):
+        """Ferma il thread impostando l'evento di stop."""
+        self.stop_event.set()

--- a/uv.lock
+++ b/uv.lock
@@ -102,6 +102,8 @@ dependencies = [
     { name = "ctkmessagebox" },
     { name = "customtkinter" },
     { name = "glfw" },
+    { name = "imageio" },
+    { name = "imageio-ffmpeg" },
     { name = "numpy" },
     { name = "pillow" },
     { name = "pyopengl" },
@@ -115,6 +117,8 @@ requires-dist = [
     { name = "ctkmessagebox" },
     { name = "customtkinter" },
     { name = "glfw" },
+    { name = "imageio", specifier = ">=2.37.3" },
+    { name = "imageio-ffmpeg", specifier = ">=0.6.0" },
     { name = "numpy" },
     { name = "pillow" },
     { name = "pyopengl" },
@@ -153,6 +157,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
     { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
     { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
+]
+
+[[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
The fullscreen OpenGL backend can now play a **looping (muted) video** behind the bars, as an alternative to the static image background. This is an **OpenGL-only** feature: the in-window Tkinter preview is unchanged and shows a text placeholder when a video is selected.

Image and video are **mutually exclusive** (selecting one stops the other). The equalizer keeps reacting to captured **system** audio — the video's own audio is never decoded or played.

## Main changes
- **`thread/video_decode_thread.py`** (new): dedicated CPU producer decoding frames (`imageio`/ffmpeg) into a short queue (`maxsize=2`), looping at EOF and releasing the ffmpeg subprocess on stop. Same producer/consumer pattern as the audio path.
- **`thread/opengl_thread.py`**: `uFlipV` shader uniform (flip video rows on the GPU, no per-frame CPU copy); a dedicated video texture updated per frame (`glTexImage2D` once + in-place `glTexSubImage2D`, `GL_UNPACK_ALIGNMENT=1`); **fps-paced** advance decoupled from VSync (consumes only the due frames, so the decoder back-pressures to real time — no speed-up); `set_video`/`clear_video` control messages; `_stop_video` + extended `_cleanup_gl`.
- **GUI**: file picker accepts video files; extension-based dispatch in `apply_bg_command`; text placeholder in the in-window preview; `bg_video` passed to the OpenGL thread on fullscreen.
- **Packaging**: bundle `imageio_ffmpeg` (`--collect-all`) + lazy-plugin hidden imports in `py-to-exe-settings.json`.
- **Dependencies**: add `imageio`, `imageio-ffmpeg`.

## Testing
- Standalone decoder (RGB frames, fps, looping).
- Real GLSL shader compilation + video texture upload in an offscreen GL context.
- End-to-end pipeline (`set_video` → advance → upload → render → `set_image`) with no GL errors.
- **Pacing**: 30 fps on 60/144 Hz and 60 fps on 30/60 Hz all at 1.00× (fixed an initial bug where the video ran at ~2×).
- Manually verified on Windows: works as expected.

## Follow-up
Run **`uv sync` on Windows** to install the new dependencies into the Windows `.venv` before running/building there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)