### PR TITLE
Add adjustable bar opacity to the OpenGL renderer

### DIFF
--- a/gui/main_window_gui.py
+++ b/gui/main_window_gui.py
@@ -59,6 +59,7 @@ class AudioCaptureGUI(ctk.CTk):
         self.devices = []
         self.canvas_width = self.canvas_height = None
         self.bg_alpha = 0.5
+        self.bars_alpha = 1.0  # opacità delle barre nel renderer OpenGL (1.0 = piene)
         self.bg_video_path = None  # path del video di sfondo selezionato (None = immagine)
         self.selected_monitor = None
         self.available_monitors = self.get_available_monitors()
@@ -343,14 +344,23 @@ class AudioCaptureGUI(ctk.CTk):
         )
         self.file_picker.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
 
-        # Trasparenza
+        # Trasparenza dello sfondo (immagine o video)
         self.alpha_slider = SliderCustomFrame(
             vis_tab,
-            header_name='Trasparenza:',
+            header_name='Trasparenza sfondo:',
             command=self.update_alpha,
             initial_value=self.bg_alpha
         )
         self.alpha_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
+
+        # Opacità delle barre (solo renderer OpenGL)
+        self.bars_alpha_slider = SliderCustomFrame(
+            vis_tab,
+            header_name='Opacità barre:',
+            command=self.update_bars_alpha,
+            initial_value=self.bars_alpha
+        )
+        self.bars_alpha_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
 
         # Selettore monitor per il fullscreen (solo con più monitor disponibili)
         if len(self.available_monitors) > 1:
@@ -495,6 +505,17 @@ class AudioCaptureGUI(ctk.CTk):
         if self.equalizer_opengl_thread:
             message = {
                 "type": "set_alpha",
+                "value": float(value)
+            }
+            self.equalizer_control_queue.put(message)
+
+    def update_bars_alpha(self, value):
+        # L'opacità delle barre è gestita solo dal renderer OpenGL: la preview
+        # Tkinter disegna rettangoli pieni e non ha un concetto di alpha barre.
+        self.bars_alpha = value
+        if self.equalizer_opengl_thread:
+            message = {
+                "type": "set_bars_alpha",
                 "value": float(value)
             }
             self.equalizer_control_queue.put(message)
@@ -659,6 +680,7 @@ class AudioCaptureGUI(ctk.CTk):
                     control_queue=self.equalizer_control_queue,
                     bg_image=self.bg_img,
                     bg_alpha=self.bg_alpha,
+                    bars_alpha=self.bars_alpha,
                     bg_video=self.bg_video_path,
                     monitor=self.selected_monitor,
                     window_close_callback=self.opengl_window_closed

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -72,12 +72,13 @@ in float vFill;
 out vec4 FragColor;
 uniform float uGreenSplit;
 uniform float uYellowSplit;
+uniform float uBarsAlpha;
 void main() {
     vec3 col;
     if (vFill < uGreenSplit)        col = vec3(0.0, 1.0, 0.0);
     else if (vFill < uYellowSplit)  col = vec3(1.0, 1.0, 0.0);
     else                            col = vec3(1.0, 0.0, 0.0);
-    FragColor = vec4(col, 1.0);
+    FragColor = vec4(col, uBarsAlpha);
 }
 """
 
@@ -144,6 +145,7 @@ class EqualizerOpenGLThread(threading.Thread):
                  monitor=None,
                  bg_image: Optional[Image.Image] = None,
                  bg_alpha: Optional[float] = None,
+                 bars_alpha: float = 1.0,
                  bg_video: Optional[str] = None,
                  window_close_callback: Callable = None):
         super().__init__()
@@ -155,6 +157,7 @@ class EqualizerOpenGLThread(threading.Thread):
         self._monitor = monitor
         self._bg_image = bg_image
         self._bg_alpha = bg_alpha
+        self._bars_alpha = bars_alpha
         self.window_close_callback = window_close_callback
 
         # Oggetti OpenGL (creati in init_gl_objects una volta attivo il contesto)
@@ -348,7 +351,7 @@ class EqualizerOpenGLThread(threading.Thread):
         )
         self._bars_uniforms = {
             name: glGetUniformLocation(self._bars_program, name)
-            for name in ("uNumBars", "uBarWidthFrac", "uGreenSplit", "uYellowSplit")
+            for name in ("uNumBars", "uBarWidthFrac", "uGreenSplit", "uYellowSplit", "uBarsAlpha")
         }
         self._bg_uniforms = {
             name: glGetUniformLocation(self._bg_program, name)
@@ -464,6 +467,7 @@ class EqualizerOpenGLThread(threading.Thread):
         glUniform1f(self._bars_uniforms["uBarWidthFrac"], BAR_WIDTH_FRAC)
         glUniform1f(self._bars_uniforms["uGreenSplit"], GREEN_SPLIT)
         glUniform1f(self._bars_uniforms["uYellowSplit"], YELLOW_SPLIT)
+        glUniform1f(self._bars_uniforms["uBarsAlpha"], float(self._bars_alpha))
         glBindVertexArray(self._bars_vao)
         glDrawArraysInstanced(GL_TRIANGLES, 0, 6, num_bars)
         glBindVertexArray(0)
@@ -523,6 +527,10 @@ class EqualizerOpenGLThread(threading.Thread):
         elif message_type == 'set_alpha':
             # L'alpha è una uniform dello shader di sfondo: basta memorizzarla.
             self._bg_alpha = message['value']
+
+        elif message_type == 'set_bars_alpha':
+            # L'opacità delle barre è una uniform dello shader delle barre.
+            self._bars_alpha = message['value']
 
         elif message_type == 'set_image':
             # L'immagine sostituisce il video: ferma l'eventuale riproduzione.


### PR DESCRIPTION
## Cosa

Aggiunge uno slider per regolare l'**opacità delle barre** dell'equalizzatore nel renderer OpenGL, così da lasciar intravedere lo sfondo (immagine o video) dietro di esse. È il mirror del controllo alpha dello sfondo già esistente.

## Modifiche

**Renderer — `thread/opengl_thread.py`**
- Nuova uniform `uBarsAlpha` nel fragment shader delle barre (prima l'alpha era fissata a `1.0`); spinta a ogni frame in `_render`. Il blending alpha era già abilitato e le barre sono disegnate dopo lo sfondo → si fondono correttamente.
- Nuovo parametro costruttore `bars_alpha: float = 1.0` (default: barre piene) → `self._bars_alpha`.
- Nuovo messaggio di controllo `set_bars_alpha` in `process_control_message`.

**GUI — `gui/main_window_gui.py`**
- Nuovo slider **`Opacità barre:`** nella tab Visualizzazione (callback `update_bars_alpha`, attivo solo col renderer OpenGL).
- Slider sfondo esistente rinominato in **`Trasparenza sfondo:`** per distinguere i due controlli alpha.
- Valore iniziale inoltrato al thread OpenGL alla creazione del fullscreen.

L'opacità barre è **solo OpenGL**: la preview Tkinter (rettangoli pieni) resta invariata, così come la pipeline DSP.

## Note sulla base
La PR è basata su `feature/video-background` (non su `master`) perché il branch ne discende e quel ramo non è ancora su `master`: così il diff contiene **solo** la feature opacità barre. Da rifare il target su `master` dopo il merge di `feature/video-background`.

## Test
- `python -m py_compile` su entrambi i file: OK.
- Verifica manuale: Start → Fullscreen → trascinando `Opacità barre:` le barre passano da piene (1.0) a traslucide fino a sparire (0.0); lo slider `Trasparenza sfondo:` continua ad agire solo sullo sfondo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)