### PR TITLE
Silence benign soundcard discontinuity warning; de-block audio queue

### DIFF
--- a/thread/audioCaptureThread.py
+++ b/thread/audioCaptureThread.py
@@ -1,5 +1,6 @@
 import threading
 import queue
+import warnings
 
 # Audio parameters
 CHUNK = 1024
@@ -21,7 +22,18 @@ class AudioCaptureThread(threading.Thread):
     def run(self):
         if self._debug:
             print("Audio capture thread run() called")
-        
+
+        # Le catture in loopback su WASAPI marcano discontinuita in modo
+        # fisiologico (riprese dopo il silenzio, glitch del flusso di rendering):
+        # soundcard le emette come warning a ogni occorrenza tramite
+        # simplefilter('always'). Sono benigni — i dati restano validi — quindi
+        # silenziamo solo questo messaggio. Va registrato qui (a thread avviato,
+        # dopo l'import di soundcard) perche' i filtri inseriti per ultimi hanno
+        # precedenza: cosi' il nostro 'ignore' vince sull''always' di soundcard.
+        # Filtro per messaggio (non per categoria) cosi' altri SoundcardRuntimeWarning
+        # restano visibili, ed e' cross-platform (niente import della classe).
+        warnings.filterwarnings("ignore", message="data discontinuity in recording")
+
         with self.device.recorder(samplerate=RATE, channels=self.channels) as recorder:
             while self._running:
                 try:
@@ -30,9 +42,22 @@ class AudioCaptureThread(threading.Thread):
                     data = recorder.record(numframes=CHUNK)
                     if self._debug:
                         print(f"Captured {len(data)} samples of audio data")
-                    self.audio_queue.put(data, block=True, timeout=1)
-                except queue.Full:
-                    pass
+                    # Put non bloccante: se la coda e' piena (consumer momentaneamente
+                    # fermo, es. init OpenGL) scartiamo il frame piu' vecchio e inseriamo
+                    # il piu' recente, invece di bloccare record() — un blocco starverebbe
+                    # il buffer WASAPI e fabbricherebbe discontinuita' reali. Coerente con
+                    # i consumer che tengono comunque solo l'ultimo frame.
+                    try:
+                        self.audio_queue.put_nowait(data)
+                    except queue.Full:
+                        try:
+                            self.audio_queue.get_nowait()   # scarta il frame stantio
+                        except queue.Empty:
+                            pass
+                        try:
+                            self.audio_queue.put_nowait(data)
+                        except queue.Full:
+                            pass
                 except Exception as exception:
                     print(f"Error capturing audio: {exception}")
                     break


### PR DESCRIPTION
## Problema

Agganciandosi a un dispositivo audio in **loopback** (`sc.all_microphones(include_loopback=True)`), la console si riempie di:

```
SoundcardRuntimeWarning: data discontinuity in recording  (mediafoundation.py:772)
```

**Causa radice.** Il backend WASAPI di `soundcard` emette il warning ogni volta che `IAudioCaptureClient::GetBuffer()` ritorna il flag `AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY` su un pacchetto non-primo. In loopback questa discontinuità è **fisiologica** (a ogni ripresa dopo un tratto di silenzio/idle del flusso di rendering, e sui glitch); `soundcard` la stampa a ogni occorrenza tramite `simplefilter('always', ...)`. I dati restano validi e l'equalizer reagisce normalmente — è solo rumore nei log.

**Contributo secondario.** Il `put(block=True, timeout=1)` del loop di cattura, quando il consumer si blocca (tipico durante l'init della finestra OpenGL), bloccava `record()` fino a 1 s: il buffer del motore WASAPI andava in overrun, fabbricando discontinuità *reali*.

## Modifiche (`thread/audioCaptureThread.py`)

1. **Soppressione mirata del warning** — filtro `warnings` per messaggio, registrato in cima a `run()` (dopo l'import di `soundcard`, così ha precedenza sull'`always`). Silenzia solo `"data discontinuity in recording"`; altri `SoundcardRuntimeWarning` restano visibili. Cross-platform (nessun import della classe).
2. **Coda non bloccante drop-oldest** — `put_nowait` che, a coda piena, scarta il frame più vecchio e inserisce il più recente, così `record()` non si blocca mai sul `put` durante gli stall transitori del consumer. Coerente con i consumer che tengono comunque solo l'ultimo frame.

## Verifica

- Logica verificata su WSL2: il filtro sopprime il messaggio target lasciando visibili gli altri warning; la coda `maxsize=2` dopo 5 frame mantiene i 2 più recenti senza bloccare. `py_compile` OK.
- Verifica end-to-end **da fare su Windows** (WSL2 usa PulseAudio, che non emette questo warning): `uv run python main.py` → loopback + fullscreen OpenGL + audio con pause → atteso nessun `data discontinuity in recording`, barre reattive.