### PR TITLE
Add adjustable bar opacity to the OpenGL renderer

### DIFF
--- a/gui/main_window_gui.py
+++ b/gui/main_window_gui.py
@@ -59,6 +59,7 @@ class AudioCaptureGUI(ctk.CTk):
         self.devices = []
         self.canvas_width = self.canvas_height = None
         self.bg_alpha = 0.5
+        self.bars_alpha = 1.0  # opacità delle barre nel renderer OpenGL (1.0 = piene)
         self.bg_video_path = None  # path del video di sfondo selezionato (None = immagine)
         self.selected_monitor = None
         self.available_monitors = self.get_available_monitors()
@@ -343,14 +344,23 @@ class AudioCaptureGUI(ctk.CTk):
         )
         self.file_picker.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
 
-        # Trasparenza
+        # Trasparenza dello sfondo (immagine o video)
         self.alpha_slider = SliderCustomFrame(
             vis_tab,
-            header_name='Trasparenza:',
+            header_name='Trasparenza sfondo:',
             command=self.update_alpha,
             initial_value=self.bg_alpha
         )
         self.alpha_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
+
+        # Opacità delle barre (solo renderer OpenGL)
+        self.bars_alpha_slider = SliderCustomFrame(
+            vis_tab,
+            header_name='Opacità barre:',
+            command=self.update_bars_alpha,
+            initial_value=self.bars_alpha
+        )
+        self.bars_alpha_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
 
         # Selettore monitor per il fullscreen (solo con più monitor disponibili)
         if len(self.available_monitors) > 1:
@@ -495,6 +505,17 @@ class AudioCaptureGUI(ctk.CTk):
         if self.equalizer_opengl_thread:
             message = {
                 "type": "set_alpha",
+                "value": float(value)
+            }
+            self.equalizer_control_queue.put(message)
+
+    def update_bars_alpha(self, value):
+        # L'opacità delle barre è gestita solo dal renderer OpenGL: la preview
+        # Tkinter disegna rettangoli pieni e non ha un concetto di alpha barre.
+        self.bars_alpha = value
+        if self.equalizer_opengl_thread:
+            message = {
+                "type": "set_bars_alpha",
                 "value": float(value)
             }
             self.equalizer_control_queue.put(message)
@@ -659,6 +680,7 @@ class AudioCaptureGUI(ctk.CTk):
                     control_queue=self.equalizer_control_queue,
                     bg_image=self.bg_img,
                     bg_alpha=self.bg_alpha,
+                    bars_alpha=self.bars_alpha,
                     bg_video=self.bg_video_path,
                     monitor=self.selected_monitor,
                     window_close_callback=self.opengl_window_closed

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -72,12 +72,13 @@ in float vFill;
 out vec4 FragColor;
 uniform float uGreenSplit;
 uniform float uYellowSplit;
+uniform float uBarsAlpha;
 void main() {
     vec3 col;
     if (vFill < uGreenSplit)        col = vec3(0.0, 1.0, 0.0);
     else if (vFill < uYellowSplit)  col = vec3(1.0, 1.0, 0.0);
     else                            col = vec3(1.0, 0.0, 0.0);
-    FragColor = vec4(col, 1.0);
+    FragColor = vec4(col, uBarsAlpha);
 }
 """
 
@@ -144,6 +145,7 @@ class EqualizerOpenGLThread(threading.Thread):
                  monitor=None,
                  bg_image: Optional[Image.Image] = None,
                  bg_alpha: Optional[float] = None,
+                 bars_alpha: float = 1.0,
                  bg_video: Optional[str] = None,
                  window_close_callback: Callable = None):
         super().__init__()
@@ -155,6 +157,7 @@ class EqualizerOpenGLThread(threading.Thread):
         self._monitor = monitor
         self._bg_image = bg_image
         self._bg_alpha = bg_alpha
+        self._bars_alpha = bars_alpha
         self.window_close_callback = window_close_callback
 
         # Oggetti OpenGL (creati in init_gl_objects una volta attivo il contesto)
@@ -348,7 +351,7 @@ class EqualizerOpenGLThread(threading.Thread):
         )
         self._bars_uniforms = {
             name: glGetUniformLocation(self._bars_program, name)
-            for name in ("uNumBars", "uBarWidthFrac", "uGreenSplit", "uYellowSplit")
+            for name in ("uNumBars", "uBarWidthFrac", "uGreenSplit", "uYellowSplit", "uBarsAlpha")
         }
         self._bg_uniforms = {
             name: glGetUniformLocation(self._bg_program, name)
@@ -464,6 +467,7 @@ class EqualizerOpenGLThread(threading.Thread):
         glUniform1f(self._bars_uniforms["uBarWidthFrac"], BAR_WIDTH_FRAC)
         glUniform1f(self._bars_uniforms["uGreenSplit"], GREEN_SPLIT)
         glUniform1f(self._bars_uniforms["uYellowSplit"], YELLOW_SPLIT)
+        glUniform1f(self._bars_uniforms["uBarsAlpha"], float(self._bars_alpha))
         glBindVertexArray(self._bars_vao)
         glDrawArraysInstanced(GL_TRIANGLES, 0, 6, num_bars)
         glBindVertexArray(0)
@@ -523,6 +527,10 @@ class EqualizerOpenGLThread(threading.Thread):
         elif message_type == 'set_alpha':
             # L'alpha è una uniform dello shader di sfondo: basta memorizzarla.
             self._bg_alpha = message['value']
+
+        elif message_type == 'set_bars_alpha':
+            # L'opacità delle barre è una uniform dello shader delle barre.
+            self._bars_alpha = message['value']
 
         elif message_type == 'set_image':
             # L'immagine sostituisce il video: ferma l'eventuale riproduzione.


### PR DESCRIPTION
## Contesto

La feature **bar opacity** era stata mergiata (PR #21) con base `feature/video-background` invece di `master`, quindi non è mai arrivata in `master`. Il video background era già su master via #20 (`d732331`).

Un merge diretto di `feature/video-background` produce conflitti **artificiali**: il video background è stato squash-mergiato in #20 (nuovo SHA), così git non riconosce la parte video-bg del branch come la stessa modifica già presente e la segnala come divergenza. Per evitarlo, qui c'è **solo** il commit della bar-opacity (`9f15ea7`) cherry-pickato pulito su `master`.

## Modifiche

- `gui/main_window_gui.py`: nuovo slider **"Opacità barre"** (`update_bars_alpha` → messaggio `set_bars_alpha` sul control queue) e passaggio di `bars_alpha` al thread OpenGL. Lo slipper agisce solo sul renderer OpenGL (la preview Tkinter disegna rettangoli pieni).
- `thread/opengl_thread.py`: nuova uniform `uBarsAlpha` nel fragment shader delle barre; `bars_alpha` come parametro del costruttore e impostato in `_render`/`process_control_message`.

Net diff: 2 file, +34/-4. Non tocca `thread/audioCaptureThread.py` (il fix #22 resta intatto).

## Verifica

- `py_compile` OK su entrambi i file.
- Verifica funzionale **su Windows** (WSL2 non ha il backend OpenGL/audio reale): avviare il fullscreen OpenGL e muovere lo slider "Opacità barre" → le barre cambiano trasparenza in tempo reale.