### PR TITLE
Expose OpenGL DSP tuning params in the GUI

### DIFF
--- a/gui/help_window.py
+++ b/gui/help_window.py
@@ -28,7 +28,16 @@ class HelpWindow(ctk.CTkToplevel):
                                  'Frequency bands: Use it to dinamically change the number of the bars showed. Take care that after some number of bars, ' \
                                  'according to your hardware it could become pretty laggy. For high number of bars is highly suggested the full screen visulization\n' \
                                  'Fullscreen button: Open a fullscreen window in which the bars are drawn. This window has high performance so it\'s ' \
-                                 'suggested when you use high number of bands.')
+                                 'suggested when you use high number of bands.\n\n' \
+                                 'Advanced (Fullscreen only)\n\n' \
+                                 'These settings tune the OpenGL fullscreen renderer and have no effect on the in-window preview. ' \
+                                 'You can change them live while fullscreen is running.\n' \
+                                 'dB floor / dB ceiling: The absolute loudness range mapped to bar height. Raise the floor (less negative) ' \
+                                 'or lower the ceiling to make the bars fill up more easily; widen the range for a less sensitive display.\n' \
+                                 'Attack (ms): How quickly bars rise. Lower values snap to transients (kick/snare) almost instantly.\n' \
+                                 'Release (ms): How slowly bars fall. Higher values give a smoother, more readable peak-meter falloff.\n' \
+                                 'Tilt (dB/octave): Spectral emphasis. Negative values boost the lows, positive values boost the highs ' \
+                                 '(e.g. +3 roughly compensates for pink-noise spectra). 0 leaves the response flat.')
         self.explaination.configure(state='disabled')
 
         self.focus()

--- a/gui/main_window_gui.py
+++ b/gui/main_window_gui.py
@@ -12,7 +12,10 @@ import glfw
 
 from thread.audioCaptureThread import AudioCaptureThread
 from thread.equalizer_tkinter_thread import EqualizerTkinterThread
-from thread.opengl_thread import EqualizerOpenGLThread
+from thread.opengl_thread import (
+    EqualizerOpenGLThread,
+    DB_FLOOR, DB_CEILING, ATTACK_TAU, RELEASE_TAU, TILT_DB_PER_OCT,
+)
 from gui.slider_frame import SliderCustomFrame
 from gui.optionmenu_frame import OptionMenuCustomFrame
 from gui.background_filepicker_frame import BackgroundFilepickerFrame
@@ -316,6 +319,7 @@ class AudioCaptureGUI(ctk.CTk):
 
         self._build_visualization_tab(tabview)
         self._build_audio_tab(tabview)
+        self._build_advanced_tab(tabview)
 
     def _build_visualization_tab(self, tabview):
         """
@@ -402,6 +406,76 @@ class AudioCaptureGUI(ctk.CTk):
             value_type=SliderCustomFrame.ValueType.INT
         )
         self.frequency_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
+
+    def _build_advanced_tab(self, tabview):
+        """
+        Tab Avanzate: taratura DSP del renderer OpenGL (scala dB, ballistica delle
+        barre, tilt spettrale). Tutti questi controlli hanno effetto SOLO nella
+        visualizzazione fullscreen OpenGL — le callback no-op se non è attiva.
+        """
+        tabview.add("⚙️ Avanzate")
+        adv_tab = tabview.tab("⚙️ Avanzate")
+
+        # Pavimento dB: sotto questo livello la barra è a 0 (più basso = più sensibile)
+        self.adv_db_floor_slider = SliderCustomFrame(
+            adv_tab,
+            header_name='Pavimento dB:',
+            command=self.update_db_floor,
+            from_=-90,
+            to=-25,
+            initial_value=int(DB_FLOOR),
+            value_type=SliderCustomFrame.ValueType.INT
+        )
+        self.adv_db_floor_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
+
+        # Tetto dB: fondo scala, barra piena (più basso = riempie prima)
+        self.adv_db_ceiling_slider = SliderCustomFrame(
+            adv_tab,
+            header_name='Tetto dB:',
+            command=self.update_db_ceiling,
+            from_=-20,
+            to=6,
+            initial_value=int(DB_CEILING),
+            value_type=SliderCustomFrame.ValueType.INT
+        )
+        self.adv_db_ceiling_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
+
+        # Attacco (ms): velocità di salita delle barre
+        self.adv_attack_slider = SliderCustomFrame(
+            adv_tab,
+            header_name='Attacco (ms):',
+            command=self.update_attack_tau,
+            from_=1,
+            to=100,
+            initial_value=int(ATTACK_TAU * 1000),
+            value_type=SliderCustomFrame.ValueType.INT
+        )
+        self.adv_attack_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
+
+        # Rilascio (ms): velocità di discesa delle barre
+        self.adv_release_slider = SliderCustomFrame(
+            adv_tab,
+            header_name='Rilascio (ms):',
+            command=self.update_release_tau,
+            from_=20,
+            to=1000,
+            initial_value=int(RELEASE_TAU * 1000),
+            value_type=SliderCustomFrame.ValueType.INT
+        )
+        self.adv_release_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
+
+        # Tilt spettrale (dB/ottava): enfatizza bassi (<0) o alti (>0)
+        self.adv_tilt_slider = SliderCustomFrame(
+            adv_tab,
+            header_name='Tilt (dB/ottava):',
+            command=self.update_tilt,
+            from_=-6,
+            to=6,
+            steps=24,
+            initial_value=TILT_DB_PER_OCT,
+            value_type=SliderCustomFrame.ValueType.DOUBLE
+        )
+        self.adv_tilt_slider.pack(side=tk.TOP, padx=10, pady=5, fill=tk.X)
 
     def apply_background(self):
         # Rimuovi un eventuale segnaposto video: stiamo tornando a un'immagine.
@@ -519,6 +593,28 @@ class AudioCaptureGUI(ctk.CTk):
                 "value": float(value)
             }
             self.equalizer_control_queue.put(message)
+
+    def update_db_floor(self, value):
+        # Parametri DSP del tab Avanzate: solo renderer OpenGL (come bars_alpha).
+        if self.equalizer_opengl_thread:
+            self.equalizer_control_queue.put({"type": "set_db_floor", "value": float(value)})
+
+    def update_db_ceiling(self, value):
+        if self.equalizer_opengl_thread:
+            self.equalizer_control_queue.put({"type": "set_db_ceiling", "value": float(value)})
+
+    def update_attack_tau(self, value):
+        # Lo slider è in millisecondi; la pipeline DSP lavora in secondi.
+        if self.equalizer_opengl_thread:
+            self.equalizer_control_queue.put({"type": "set_attack_tau", "value": float(value) / 1000.0})
+
+    def update_release_tau(self, value):
+        if self.equalizer_opengl_thread:
+            self.equalizer_control_queue.put({"type": "set_release_tau", "value": float(value) / 1000.0})
+
+    def update_tilt(self, value):
+        if self.equalizer_opengl_thread:
+            self.equalizer_control_queue.put({"type": "set_tilt_db_per_oct", "value": float(value)})
 
     def update_bg_opengl(self, image: Image.Image):
         if self.equalizer_opengl_thread:
@@ -682,6 +778,11 @@ class AudioCaptureGUI(ctk.CTk):
                     bg_alpha=self.bg_alpha,
                     bars_alpha=self.bars_alpha,
                     bg_video=self.bg_video_path,
+                    db_floor=self.adv_db_floor_slider.get_value(),
+                    db_ceiling=self.adv_db_ceiling_slider.get_value(),
+                    attack_tau=self.adv_attack_slider.get_value() / 1000.0,
+                    release_tau=self.adv_release_slider.get_value() / 1000.0,
+                    tilt_db_per_oct=self.adv_tilt_slider.get_value(),
                     monitor=self.selected_monitor,
                     window_close_callback=self.opengl_window_closed
                 )

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -147,6 +147,11 @@ class EqualizerOpenGLThread(threading.Thread):
                  bg_alpha: Optional[float] = None,
                  bars_alpha: float = 1.0,
                  bg_video: Optional[str] = None,
+                 db_floor: float = DB_FLOOR,
+                 db_ceiling: float = DB_CEILING,
+                 attack_tau: float = ATTACK_TAU,
+                 release_tau: float = RELEASE_TAU,
+                 tilt_db_per_oct: float = TILT_DB_PER_OCT,
                  window_close_callback: Callable = None):
         super().__init__()
         self._audio_queue = audio_queue
@@ -159,6 +164,15 @@ class EqualizerOpenGLThread(threading.Thread):
         self._bg_alpha = bg_alpha
         self._bars_alpha = bars_alpha
         self.window_close_callback = window_close_callback
+
+        # --- Taratura DSP regolabile a runtime (default = costanti di modulo). ---
+        # I metodi leggono questi attributi, non le costanti globali, così la GUI
+        # può modificarli via process_control_message (vedi set_db_floor & co.).
+        self._db_floor = db_floor
+        self._db_ceiling = db_ceiling
+        self._attack_tau = attack_tau
+        self._release_tau = release_tau
+        self._tilt_db_per_oct = tilt_db_per_oct
 
         # Oggetti OpenGL (creati in init_gl_objects una volta attivo il contesto)
         self._bars_program = None
@@ -228,12 +242,12 @@ class EqualizerOpenGLThread(threading.Thread):
         self._valid_bins = bin_band >= 0
 
         # Tilt spettrale opzionale (dB per banda), basato sulla freq. centrale geometrica
-        if TILT_DB_PER_OCT != 0.0:
+        if self._tilt_db_per_oct != 0.0:
             centers = np.array([
                 math.sqrt(max(low, 1e-9) * max(high, 1e-9))
                 for low, high in self.frequency_bands
             ])
-            self._tilt_db = TILT_DB_PER_OCT * np.log2(np.maximum(centers, 1e-9) / 1000.0)
+            self._tilt_db = self._tilt_db_per_oct * np.log2(np.maximum(centers, 1e-9) / 1000.0)
         else:
             self._tilt_db = 0.0
 
@@ -319,8 +333,11 @@ class EqualizerOpenGLThread(threading.Thread):
         # Conversione in dB (+ tilt percettivo opzionale)
         band_db = 10.0 * np.log10(band_power + 1e-12) + self._tilt_db
 
-        # Mappa [DB_FLOOR, DB_CEILING] → [0, 1] con riferimento FISSO (no per-frame max)
-        level = (band_db - DB_FLOOR) / (DB_CEILING - DB_FLOOR)
+        # Mappa [db_floor, db_ceiling] → [0, 1] con riferimento FISSO (no per-frame max).
+        # max(..., 1e-6) protegge da una divisione degenere se i due estremi
+        # venissero impostati troppo vicini/invertiti via control message.
+        denom = max(self._db_ceiling - self._db_floor, 1e-6)
+        level = (band_db - self._db_floor) / denom
         np.clip(level, 0.0, 1.0, out=level)
 
         # Noise gate in termini normalizzati
@@ -532,6 +549,29 @@ class EqualizerOpenGLThread(threading.Thread):
             # L'opacità delle barre è una uniform dello shader delle barre.
             self._bars_alpha = message['value']
 
+        elif message_type == 'set_db_floor':
+            # dB sotto cui la barra è a 0. Letto ogni frame in create_equalizer.
+            self._db_floor = message['value']
+
+        elif message_type == 'set_db_ceiling':
+            # dB di fondo scala (barra piena).
+            self._db_ceiling = message['value']
+
+        elif message_type == 'set_attack_tau':
+            # Costante di tempo di salita (s) della ballistica delle barre.
+            self._attack_tau = message['value']
+
+        elif message_type == 'set_release_tau':
+            # Costante di tempo di discesa (s) della ballistica delle barre.
+            self._release_tau = message['value']
+
+        elif message_type == 'set_tilt_db_per_oct':
+            # Il tilt è un array dB per-banda: va ricalcolato. _compute_band_bins
+            # rifà tilt e mappa bin→banda (costo trascurabile) senza azzerare i
+            # buffer ampiezze (a differenza di _setup_bands), evitando glitch.
+            self._tilt_db_per_oct = message['value']
+            self._compute_band_bins()
+
         elif message_type == 'set_image':
             # L'immagine sostituisce il video: ferma l'eventuale riproduzione.
             self._stop_video()
@@ -567,8 +607,8 @@ class EqualizerOpenGLThread(threading.Thread):
         if targets.shape[0] != self.current_amplitudes.shape[0]:
             self.current_amplitudes = np.zeros(targets.shape[0], dtype=np.float32)
 
-        attack = 1.0 - math.exp(-delta_time / ATTACK_TAU)
-        release = 1.0 - math.exp(-delta_time / RELEASE_TAU)
+        attack = 1.0 - math.exp(-delta_time / self._attack_tau)
+        release = 1.0 - math.exp(-delta_time / self._release_tau)
 
         coeff = np.where(targets > self.current_amplitudes, attack, release)
         self.current_amplitudes = self.current_amplitudes + (targets - self.current_amplitudes) * coeff


### PR DESCRIPTION
## Cosa

Rende configurabili a runtime, da un nuovo tab **⚙️ Avanzate**, cinque parametri di taratura del renderer OpenGL finora hardcoded come costanti di modulo (modificabili solo editando il sorgente e riavviando):

| Parametro | Costante | Effetto |
|---|---|---|
| Pavimento dB | `DB_FLOOR` | Sotto questo livello la barra è a 0 (più basso = più sensibile) |
| Tetto dB | `DB_CEILING` | Fondo scala / barra piena (più basso = riempie prima) |
| Attacco (ms) | `ATTACK_TAU` | Velocità di salita delle barre |
| Rilascio (ms) | `RELEASE_TAU` | Velocità di discesa delle barre |
| Tilt (dB/ottava) | `TILT_DB_PER_OCT` | Enfasi bassi (<0) vs alti (>0) |

Sono parametri **solo OpenGL** (il renderer Tkinter usa un DSP diverso, volutamente non sincronizzato). Riusa il pattern esistente di `set_bars_alpha`: slider → `equalizer_control_queue` → `process_control_message` → `self._...`.

## Come

**Renderer (`thread/opengl_thread.py`)**
- `__init__` accetta i 5 nuovi parametri (default = costanti di modulo, unica fonte di verità) e li memorizza in `self._...`, prima di `_setup_bands` così il tilt è pronto per `_compute_band_bins`.
- `create_equalizer` / `smooth_amplitudes` / `_compute_band_bins` leggono gli attributi invece dei globali. La mappa dB protegge la divisione con `max(..., 1e-6)` contro range degeneri/invertiti.
- `process_control_message`: 5 nuovi rami. `set_tilt_db_per_oct` richiama `_compute_band_bins()` (ricalcola il tilt per-banda senza azzerare i buffer ampiezze → niente glitch).

**GUI (`gui/main_window_gui.py`)**
- Nuovo tab "Avanzate" con 5 slider; gli intervalli dB non si sovrappongono → il pavimento non può mai superare il tetto. Attacco/rilascio in ms, convertiti in secondi. Valori iniziali dalle costanti importate.
- 5 callback OpenGL-only (guard `if self.equalizer_opengl_thread`, come `bars_alpha`); i valori correnti degli slider sono passati al thread al lancio fullscreen.

**Help**: documentata la sezione "Advanced (Fullscreen only)".

## Verifica

- ✅ Smoke test headless (numpy puro, no contesto GL): parametri memorizzati, livelli in [0,1], tilt ricalcolato preservando le ampiezze, guard sul range degenere.
- ✅ `py_compile` sui 3 file; import del modulo GUI + presenza dei 6 nuovi metodi + risoluzione dei 5 costanti.
- ✅ Verifica end-to-end manuale in fullscreen con audio live (display reale): gli slider hanno effetto immediato senza glitch/crash.