### PR TITLE
CI: build & attach Windows/Linux executables on release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,74 @@
+name: Build & attach release executables
+
+# Builds the one-dir PyInstaller bundle on Windows and Linux and attaches the
+# zipped artifacts to the GitHub release that triggered the run.
+#
+# Triggers:
+#   * release: published   -> automatic, when you publish a release (e.g. 1.4.0)
+#   * workflow_dispatch     -> manual, to (re)build & attach to an existing tag
+#
+# NOTE: for the `release` trigger to fire, this file must live on the default
+# branch (master). On a feature branch it only runs via workflow_dispatch.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build & attach (e.g. 1.4.0)"
+        required: true
+
+permissions:
+  contents: write   # needed to upload assets to the release
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact: sound-wave-windows
+          - os: ubuntu-22.04        # oldest supported Ubuntu -> widest glibc compatibility
+            artifact: sound-wave-linux
+    steps:
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tagged source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Build one-dir bundle (PyInstaller)
+        run: uv run --with pyinstaller pyinstaller --noconfirm sound-wave.spec
+
+      - name: Package bundle (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cd dist
+          zip -r "../${{ matrix.artifact }}.zip" "sound wave"
+
+      - name: Package bundle (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path "dist/sound wave" -DestinationPath "${{ matrix.artifact }}.zip"
+
+      - name: Attach artifact to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.tag.outputs.tag }}" "${{ matrix.artifact }}.zip" --clobber --repo "${{ github.repository }}"

--- a/sound-wave.spec
+++ b/sound-wave.spec
@@ -1,0 +1,88 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# Cross-platform PyInstaller spec for "Sound Wave" (one-dir build).
+#
+# Mirrors the historical auto-py-to-exe config (py-to-exe-settings.json) but is
+# OS-agnostic: it is the single source of truth used by both the GitHub Actions
+# release workflow (.github/workflows/release-build.yml) and manual local builds:
+#
+#     uv run --with pyinstaller pyinstaller --noconfirm sound-wave.spec
+#
+# Output: dist/sound wave/  (a one-dir bundle; the launcher is "sound wave[.exe]").
+#
+# Platform notes:
+#  * customtkinter / CTkMessagebox ship runtime assets (themes, icons) loaded by
+#    relative path, so their whole package payload must be collected.
+#  * imageio_ffmpeg bundles a static ffmpeg binary used to decode video
+#    backgrounds; collect_all pulls it in (imageio loads plugins lazily, hence
+#    the explicit hidden imports).
+#  * The `glfw` wheel bundles the GLFW shared library per-platform
+#    (libglfw.so on Linux, glfw3.dll on Windows) -> collected for every OS.
+#    On Windows we ALSO ship the repo's own glfw3.dll next to the launcher as a
+#    fallback, matching the proven manual build.
+
+import os
+import sys
+
+from PyInstaller.utils.hooks import collect_all
+
+datas = []
+binaries = []
+hiddenimports = ['imageio', 'imageio_ffmpeg', 'imageio.plugins.ffmpeg']
+
+# Collect full package payloads (data files, bundled native libs, submodules).
+for _pkg in ('customtkinter', 'CTkMessagebox', 'imageio_ffmpeg', 'glfw'):
+    _d, _b, _h = collect_all(_pkg)
+    datas += _d
+    binaries += _b
+    hiddenimports += _h
+
+# Project assets (resources/bg, resources/icons).
+datas.append((os.path.join(SPECPATH, 'resources'), 'resources'))
+
+# Windows ships its own glfw3.dll alongside the executable.
+if sys.platform == 'win32':
+    binaries.append((os.path.join(SPECPATH, 'glfw3.dll'), '.'))
+
+a = Analysis(
+    [os.path.join(SPECPATH, 'main.py')],
+    pathex=[SPECPATH],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='sound wave',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name='sound wave',
+)


### PR DESCRIPTION
## Cosa

Automatizza la creazione di eseguibili **one-dir** per **Windows** e **Linux** ad ogni release, allegandoli automaticamente alla release stessa.

## Come

- **`sound-wave.spec`** — spec PyInstaller cross-platform (unica fonte di verità per CI e build manuali). Fa `collect_all` di `customtkinter`/`CTkMessagebox`/`imageio_ffmpeg`/`glfw`, include `resources/` e gli hidden import di `imageio`; su **Windows** aggiunge anche il `glfw3.dll` del repo accanto al launcher (su Linux/macOS il wheel `glfw` porta già la sua shared lib).
- **`.github/workflows/release-build.yml`** — matrix `windows-latest` + `ubuntu-22.04`; per ogni runner: `uv sync --frozen` → `uv run --with pyinstaller pyinstaller --noconfirm sound-wave.spec` → zip di `dist/sound wave/` → `gh release upload --clobber`. PyInstaller non cross-compila, da cui un runner per SO.

## Trigger

- `release: published` → automatico (richiede che il file sia su `master`).
- `workflow_dispatch` → manuale, passando un tag esistente (utile per ribuildare release già pubblicate, es. `1.4.0`).

## Note / caveat

- Il workflow diventa attivo solo dopo il **merge su `master`** (i trigger `release`/`workflow_dispatch` valgono dal branch di default).
- Binario **Linux**: costruito su Ubuntu 22.04 → gira su quella glibc o più recente. A **runtime** Linux richiede PulseAudio/PipeWire (per `soundcard`) e un display con OpenGL — dipendenze della macchina utente, non incluse nel bundle. Windows non ha questi caveat.
- La correttezza end-to-end si verifica solo alla prima esecuzione reale su Actions.
