### PR TITLE
Fix release-build CI (Python pin, PyInstaller env, spec for old tags)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -26,6 +26,8 @@ jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      UV_PYTHON: "3.12"   # pin a single interpreter across OSes (matches requires-python)
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +46,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0   # full history so the build recipe can be restored for old tags
+
+      - name: Ensure build recipe present
+        # Tags created before this workflow existed don't carry sound-wave.spec;
+        # restore it (and the workflow dir) from the commit the run was triggered on.
+        shell: bash
+        run: |
+          if [ ! -f sound-wave.spec ]; then
+            echo "sound-wave.spec absent at ${{ steps.tag.outputs.tag }}; restoring from ${{ github.sha }}"
+            git checkout "${{ github.sha }}" -- sound-wave.spec
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -54,7 +67,11 @@ jobs:
         run: uv sync --frozen
 
       - name: Build one-dir bundle (PyInstaller)
-        run: uv run --with pyinstaller pyinstaller --noconfirm sound-wave.spec
+        # Install PyInstaller into the synced project venv (so it sees every
+        # project dependency), then build without re-syncing (which would drop it).
+        run: |
+          uv pip install pyinstaller
+          uv run --no-sync pyinstaller --noconfirm sound-wave.spec
 
       - name: Package bundle (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Contesto

Alla prima esecuzione, `release-build.yml` è fallito su entrambi i runner (Windows + Linux) allo step PyInstaller. Questa PR corregge i problemi emersi solo a runtime.

## Fix

1. **`Spec file "sound-wave.spec" not found!`** — il `workflow_dispatch` fa checkout del tag richiesto, ma i tag **precedenti** a questo workflow (es. `1.4.0`) non contengono `sound-wave.spec`. Aggiunto `fetch-depth: 0` e uno step che, se lo spec manca al ref estratto, lo ripristina dal commit che ha avviato la run (`github.sha`). Per le release future lo spec è già nel tag, quindi lo step è no-op.
2. **Ambiente di build fragile** — `uv run --with pyinstaller` creava un env effimero che su Linux ha scelto **Python 3.14** (su Windows 3.12), rischiando di non includere le dipendenze del progetto. Ora: `UV_PYTHON=3.12` fissato, PyInstaller installato nel venv sincronizzato (`uv pip install pyinstaller`) ed eseguito con `uv run --no-sync` (così il sync automatico non lo rimuove).

## Verifica

Dopo il merge rilancio `workflow_dispatch` con tag `1.4.0` per confermare che la build completi e alleghi gli zip alla release.
