### PR TITLE
Add MSAA 4x antialiasing to the OpenGL visualizations

### DIFF
--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -57,6 +57,11 @@ BAR_WIDTH_FRAC = 0.8    # frazione dello slot occupata dalla barra (il resto è 
 GREEN_SPLIT = 0.5       # sotto questa frazione d'altezza finestra → verde
 YELLOW_SPLIT = 0.8      # tra GREEN_SPLIT e questa → giallo; oltre → rosso
 
+# --- Antialiasing ---
+# Campioni MSAA richiesti sul framebuffer di default (smussa i bordi di tutte le
+# modalità). Fissato alla creazione della finestra: non modificabile a caldo.
+MSAA_SAMPLES = 4
+
 # --- Modalità di visualizzazione (Blocco 3) ---
 MODE_BARS = 0          # barre verticali (attuale, default)
 MODE_RADIAL = 1        # barre disposte in cerchio
@@ -1486,6 +1491,8 @@ class EqualizerOpenGLThread(threading.Thread):
             glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
             glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
             glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, glfw.TRUE)
+            # MSAA: richiedi un framebuffer di default multisample (antialiasing hardware).
+            glfw.window_hint(glfw.SAMPLES, MSAA_SAMPLES)
 
             window = glfw.create_window(self.window_width, self.window_height, "Audio Visualizer", selected_monitor, None)
             if not window:
@@ -1511,6 +1518,11 @@ class EqualizerOpenGLThread(threading.Thread):
             glEnable(GL_BLEND)
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
             glClearColor(0.0, 0.0, 0.0, 1.0)
+
+            # Abilita l'MSAA (no-op se il driver non ha concesso il framebuffer multisample)
+            glEnable(GL_MULTISAMPLE)
+            if GENERAL_LOG:
+                print(f"[GL] MSAA samples concessi: {glGetIntegerv(GL_SAMPLES)}")
 
             # Disable auto iconify
             glfw.set_window_attrib(window, glfw.AUTO_ICONIFY, glfw.FALSE)


### PR DESCRIPTION
## What

Enables hardware multisample antialiasing (**MSAA 4x**) on the fullscreen OpenGL renderer.

- Request a multisampled default framebuffer via `glfw.window_hint(glfw.SAMPLES, MSAA_SAMPLES)` before window creation.
- Enable `GL_MULTISAMPLE` in the GL state setup, with an optional sample-count log behind the existing `GENERAL_LOG` flag.
- New module-level constant `MSAA_SAMPLES = 4` alongside the other tuning knobs.

## Why

Until now the only antialiasing was the analytic rounded-cap AA in the bars fragment shader, active only when rounded caps are enabled. Bar vertical edges, flat tops, radial arcs, peak-cap dashes, and the oscilloscope/line/area ribbons were all aliased. MSAA smooths the geometry of **every mode** uniformly and **coexists** with the existing analytic cap AA (no shader changes, no regression).

## Notes / scope

- Sample count is fixed at window creation (not live-changeable); always on at 4x, no GUI control — by design.
- Degrades gracefully: if the driver doesn't grant a multisample framebuffer, `glEnable(GL_MULTISAMPLE)` is a no-op.
- The bloom prepass FBO is not multisampled, but it's blurred anyway — the crisp antialiased scene is what's shown on the default framebuffer.
- No changes to DSP, GUI, control queue, bloom, video path, or `_cleanup_gl` (the multisampled default framebuffer is owned by GLFW).

## Verification

- `python -m py_compile thread/opengl_thread.py` — passes.
- `glfw.SAMPLES`, `GL_MULTISAMPLE`, `GL_SAMPLES` resolve in the installed bindings.
- Visual check pending on a real display (Windows): `uv run python main.py` → **Avvia**, confirm smoother edges (especially Radial and thin/many bars); with `GENERAL_LOG=True` the console prints `[GL] MSAA samples concessi: 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)