### PR TITLE
OpenGL performance & windowing: borderless window + async PBO video upload

### DIFF
--- a/docs/superpowers/plans/2026-06-18-performance-windowing-opengl.md
+++ b/docs/superpowers/plans/2026-06-18-performance-windowing-opengl.md
@@ -1,0 +1,537 @@
+# Performance & windowing OpenGL — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Far reggere al renderer OpenGL i 165fps anche con il video di sfondo, passare a finestra borderless windowed, e dotarlo di una misura aggregata del frame time — restando su GL 3.3.
+
+**Architecture:** Tre interventi ortogonali su `thread/opengl_thread.py` più un piccolo helper puro nuovo. (1) Un `FrameTimeStats` puro Python che aggrega il frame time sotto `PERF_LOGS` (lo strumento di misura, costruito per primo). (2) La finestra viene creata **windowed senza decorazioni** dimensionata sul monitor scelto invece che fullscreen esclusiva. (3) L'upload del frame video passa da `glTexSubImage2D` sincrono (che stalla il thread GL) a **PBO double-buffered** (copia CPU→PBO + DMA PBO→texture asincrone).
+
+**Tech Stack:** Python 3.12+, GLFW, PyOpenGL (+accelerate) GL 3.3 core, numpy, gestione dipendenze con `uv`.
+
+## Global Constraints
+
+Ogni task eredita implicitamente questi vincoli (valori copiati dallo spec
+`docs/superpowers/specs/2026-06-18-performance-windowing-opengl-design.md`):
+
+- **Resta GL 3.3 core.** Nessun bump di versione del contesto in questo piano (PBO è core da GL 2.1, map-range da 3.0 → niente 4.x).
+- **Output visivo invariato.** Nessun cambio a GUI, algoritmo DSP, shader o semantica della control-queue. Si cambia *come* si rende, non *cosa*.
+- **Borderless sostituisce il fullscreen esclusivo** (nessuna doppia opzione in GUI).
+- **Niente test suite nel repo** (CLAUDE.md). Verifica per tipo: *assert headless* per la logica pura (no pytest — script con `assert` eseguito da `uv run python`), *smoke di import headless* per i cambi GL, e **verifica manuale su Windows (display reale, 165Hz) con `PERF_LOGS`** per il comportamento di rendering reale. **Non introdurre pytest né altre dipendenze.**
+- **Ambiente WSL2:** comandi headless via `uv run` (usa `.venv-linux`, vedi memoria `wsl2-venv-and-gl-verification`).
+- **Git:** committare come utente **Cioscos**; **NESSUN** trailer `Co-Authored-By` (regola del repo). Lavorare sul branch `feature/opengl-performance-windowing` (già creato).
+- **CLAUDE.md è gitignored** in questo repo: aggiornarlo localmente ma **non committarlo** (memoria `claude-md-untracked`).
+
+---
+
+## File Structure
+
+- **Create `thread/frame_time_stats.py`** — helper puro `FrameTimeStats` (nessuna dipendenza GL/numpy). Unica responsabilità: aggregare i delta-tempo dei frame e produrre una riga di riepilogo ogni N frame. Isolato → importabile e verificabile headless.
+- **Create `tests/test_frame_time_stats.py`** — verifica headless ad asserzioni pure del helper (eseguibile con `uv run python`, niente pytest).
+- **Modify `thread/opengl_thread.py`** — (a) import + costruzione/uso di `FrameTimeStats` nel loop sotto `PERF_LOGS`; (b) `run()`: creazione finestra borderless windowed + hoist di `glPixelStorei`; (c) `__init__`: attributi di stato dei PBO; (d) `_upload_video_frame`: upload via PBO double-buffered; (e) `_cleanup_gl`: free dei PBO.
+- **Modify `CLAUDE.md`** (locale, **non committato**) — documentare borderless + path PBO video.
+
+---
+
+### Task 1: Helper di misura `FrameTimeStats` + cablaggio in `PERF_LOGS`
+
+Costruiamo per primo lo strumento di misura: è il gate che convalida il Task 3 e decide l'eventuale escalation. È anche l'unica unità a logica pura → vera TDD headless.
+
+**Files:**
+- Create: `thread/frame_time_stats.py`
+- Create: `tests/test_frame_time_stats.py`
+- Modify: `thread/opengl_thread.py` (import dopo `:16`; init dopo `:1540`; sostituzione blocco `:1608-1610`)
+
+**Interfaces:**
+- Consumes: nulla (prima unità).
+- Produces: `class FrameTimeStats` con:
+  - `__init__(self, report_every: int = 120, budget_s: float = 1.0 / 60.0) -> None`
+  - `add(self, dt: float) -> str | None` — accumula un delta-tempo di frame (secondi); ritorna la stringa di riepilogo ogni `report_every` frame (poi azzera la finestra), altrimenti `None`.
+
+- [ ] **Step 1: Scrivi il test che fallisce**
+
+Crea `tests/test_frame_time_stats.py`:
+
+```python
+"""
+Verifica headless (niente pytest nel repo): asserzioni pure su FrameTimeStats.
+Eseguire dalla radice del repo con:  uv run python tests/test_frame_time_stats.py
+Uscita 0 + "OK" = passato.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from thread.frame_time_stats import FrameTimeStats
+
+
+def test_no_report_before_window():
+    stats = FrameTimeStats(report_every=4, budget_s=0.01)
+    assert stats.add(0.005) is None
+    assert stats.add(0.005) is None
+    assert stats.add(0.005) is None
+
+
+def test_report_at_window_boundary():
+    stats = FrameTimeStats(report_every=4, budget_s=0.01)
+    stats.add(0.005)
+    stats.add(0.005)
+    stats.add(0.015)  # oltre budget
+    report = stats.add(0.005)
+    assert report is not None, "il 4° frame deve produrre un report"
+    # avg = (0.005+0.005+0.015+0.005)/4 = 0.0075 s = 7.50 ms
+    assert "avg=7.50ms" in report, report
+    assert "min=5.00ms" in report, report
+    assert "max=15.00ms" in report, report
+    # 1 frame su 4 oltre budget = 25%
+    assert "oltre-budget=25%" in report, report
+
+
+def test_resets_after_report():
+    stats = FrameTimeStats(report_every=2, budget_s=0.01)
+    assert stats.add(0.005) is None
+    assert stats.add(0.005) is not None   # primo report
+    assert stats.add(0.005) is None       # finestra azzerata
+    assert stats.add(0.005) is not None   # secondo report
+
+
+def main():
+    test_no_report_before_window()
+    test_report_at_window_boundary()
+    test_resets_after_report()
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisce**
+
+Run: `uv run python tests/test_frame_time_stats.py`
+Expected: FAIL con `ModuleNotFoundError: No module named 'thread.frame_time_stats'`
+
+- [ ] **Step 3: Implementa il helper**
+
+Crea `thread/frame_time_stats.py`:
+
+```python
+"""
+Statistiche aggregate sul frame time per la diagnosi di performance del renderer
+OpenGL. Puro Python, nessuna dipendenza GL → importabile e verificabile headless.
+
+Accumula i delta-tempo dei frame e, ogni `report_every` frame, produce una riga
+di riepilogo (avg/min/max + percentuale di frame oltre il budget) usata sotto il
+flag PERF_LOGS per confrontare le performance prima/dopo un intervento.
+"""
+from __future__ import annotations
+
+
+class FrameTimeStats:
+    def __init__(self, report_every: int = 120, budget_s: float = 1.0 / 60.0) -> None:
+        """
+        Args:
+            report_every: numero di frame per ogni riga di riepilogo (>= 1).
+            budget_s: budget di frame time in secondi; i frame più lenti di questo
+                contano come "oltre budget" (tipicamente 1/refresh_rate).
+        """
+        if report_every < 1:
+            raise ValueError("report_every must be >= 1")
+        self._report_every = int(report_every)
+        self._budget_s = float(budget_s)
+        self._reset()
+
+    def _reset(self) -> None:
+        self._count = 0
+        self._sum = 0.0
+        self._min = float("inf")
+        self._max = 0.0
+        self._over_budget = 0
+
+    def add(self, dt: float) -> str | None:
+        """
+        Accumula un delta-tempo di frame (secondi). Ritorna una stringa di
+        riepilogo ogni `report_every` frame (e poi azzera la finestra), altrimenti
+        None.
+        """
+        self._count += 1
+        self._sum += dt
+        if dt < self._min:
+            self._min = dt
+        if dt > self._max:
+            self._max = dt
+        if dt > self._budget_s:
+            self._over_budget += 1
+
+        if self._count < self._report_every:
+            return None
+
+        report = self._format()
+        self._reset()
+        return report
+
+    def _format(self) -> str:
+        avg = self._sum / self._count
+        over_pct = 100.0 * self._over_budget / self._count
+        avg_fps = 1.0 / avg if avg > 0 else 0.0
+        return (
+            f"[PERF] {self._count} frame: "
+            f"avg={avg * 1e3:.2f}ms min={self._min * 1e3:.2f}ms max={self._max * 1e3:.2f}ms "
+            f"oltre-budget={over_pct:.0f}% "
+            f"(budget={self._budget_s * 1e3:.2f}ms, ~{avg_fps:.0f}fps medi)"
+        )
+```
+
+- [ ] **Step 4: Esegui il test e verifica che passa**
+
+Run: `uv run python tests/test_frame_time_stats.py`
+Expected: stampa `OK`, exit code 0
+
+- [ ] **Step 5: Cabla l'helper in `opengl_thread.py` — import**
+
+In `thread/opengl_thread.py`, dopo la riga 16 (`from thread.video_decode_thread import VideoDecodeThread`), aggiungi:
+
+```python
+from thread.frame_time_stats import FrameTimeStats
+```
+
+- [ ] **Step 6: Cabla — costruzione dello stats object nel `run()`**
+
+In `run()`, subito dopo `last_frame_time = glfw.get_time()` (riga ~1540), aggiungi:
+
+```python
+            # Statistiche aggregate del frame time (solo sotto PERF_LOGS): budget
+            # = 1/refresh del monitor → "oltre-budget" conta i frame che mancano il vblank.
+            frame_stats = FrameTimeStats(report_every=120, budget_s=1.0 / max(self.frame_rate, 1)) if PERF_LOGS else None
+```
+
+- [ ] **Step 7: Cabla — sostituisci la stampa per-frame nel loop**
+
+In `run()`, sostituisci il blocco esistente (righe ~1608-1610):
+
+```python
+                if PERF_LOGS and frame_delta > 0:
+                    fps = 1.0 / frame_delta
+                    print(f"PERF LOG: FrameTime = {frame_delta * 1000:.3f}ms (FPS ~ {fps:.1f})")
+```
+
+con:
+
+```python
+                if frame_stats is not None and frame_delta > 0:
+                    report = frame_stats.add(frame_delta)
+                    if report:
+                        print(report)
+```
+
+- [ ] **Step 8: Smoke di import headless**
+
+Run (dalla radice del repo): `uv run python -c "import thread.opengl_thread; print('import OK')"`
+Expected: stampa `import OK` senza traceback (conferma che import + cablaggio non rompono il modulo).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add thread/frame_time_stats.py tests/test_frame_time_stats.py thread/opengl_thread.py
+git commit -m "Add aggregated frame-time PERF_LOGS stats helper"
+```
+
+---
+
+### ⏱️ Checkpoint di misura (MANUALE — utente, Windows 165Hz)
+
+Prima di applicare il fix, cattura la **baseline** con lo strumento appena aggiunto, così il prima/dopo è quantificato:
+
+1. In `thread/opengl_thread.py` metti `PERF_LOGS = True` (riga 25). *(Modifica locale temporanea, da rimettere a `False` a fine lavoro — non committare il `True`.)*
+2. `uv run python main.py`, avvia il fullscreen **con un video di sfondo**.
+3. Annota alcune righe `[PERF] ...` (atteso: `avg` vicino/oltre il budget, `oltre-budget%` alto, `~fps medi` ~140-150 → riproduce il sintomo).
+4. Ripeti **senza** video (atteso: ~165fps, `oltre-budget≈0%`).
+
+Questi numeri sono il riferimento per validare il Task 3.
+
+---
+
+### Task 2: Finestra borderless windowed
+
+Sostituisce la creazione fullscreen esclusiva con una finestra senza decorazioni dimensionata e posizionata sul monitor scelto. Intervento indipendente e isolato al solo `run()`.
+
+**Files:**
+- Modify: `thread/opengl_thread.py` (blocco creazione finestra `:1489-1499`)
+
+**Interfaces:**
+- Consumes: `selected_monitor` (oggetto monitor GLFW già risolto sopra nel `run()`), `self.window_width`, `self.window_height` (già impostati dal video mode).
+- Produces: nessuna nuova interfaccia (cambia solo il modo di creare `window`).
+
+- [ ] **Step 1: Sostituisci il blocco di creazione finestra**
+
+In `run()`, sostituisci le righe ~1489-1499:
+
+```python
+            # Richiedi esplicitamente un contesto OpenGL 3.3 core (shader + instancing).
+            glfw.default_window_hints()
+            glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+            glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
+            glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+            glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, glfw.TRUE)
+            # MSAA: richiedi un framebuffer di default multisample (antialiasing hardware).
+            glfw.window_hint(glfw.SAMPLES, MSAA_SAMPLES)
+
+            window = glfw.create_window(self.window_width, self.window_height, "Audio Visualizer", selected_monitor, None)
+            if not window:
+                raise Exception("GLFW window creation failed")
+```
+
+con:
+
+```python
+            # Richiedi esplicitamente un contesto OpenGL 3.3 core (shader + instancing).
+            glfw.default_window_hints()
+            glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+            glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
+            glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+            glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, glfw.TRUE)
+            # MSAA: richiedi un framebuffer di default multisample (antialiasing hardware).
+            glfw.window_hint(glfw.SAMPLES, MSAA_SAMPLES)
+            # Borderless windowed (NON fullscreen esclusivo): finestra senza bordo/titolo,
+            # dimensionata e posizionata sul monitor scelto. Niente cambio di modalità video
+            # → alt-tab istantaneo e (su Windows) present al refresh del monitor senza il
+            # mode-switch dell'esclusivo. NON FLOATING: come le borderless dei giochi
+            # moderni, l'alt-tab la manda dietro.
+            glfw.window_hint(glfw.DECORATED, glfw.FALSE)
+
+            # Posizione del monitor scelto nello spazio virtuale multi-monitor.
+            monitor_x, monitor_y = glfw.get_monitor_pos(selected_monitor)
+
+            # Finestra WINDOWED (monitor=None): è la borderless, non l'esclusiva.
+            window = glfw.create_window(self.window_width, self.window_height, "Audio Visualizer", None, None)
+            if not window:
+                raise Exception("GLFW window creation failed")
+
+            # Posizionala esattamente sul monitor scelto così lo copre tutto.
+            glfw.set_window_pos(window, monitor_x, monitor_y)
+```
+
+- [ ] **Step 2: Smoke di import headless**
+
+Run: `uv run python -c "import thread.opengl_thread; print('import OK')"`
+Expected: `import OK` senza traceback.
+
+- [ ] **Step 3: Verifica manuale (MANUALE — utente, Windows)**
+
+Avvia `uv run python main.py` e apri il fullscreen. Verifica:
+- la finestra copre **tutto** il monitor selezionato, **senza bordo né barra del titolo**;
+- **alt-tab** è istantaneo (niente flash/cambio risoluzione) e manda la finestra dietro;
+- **ESC** chiude la finestra;
+- con il selettore monitor su un secondo schermo, la finestra appare **su quel** monitor;
+- con `PERF_LOGS = True`, **senza** video gli fps medi restano ~165 (`oltre-budget≈0%`) come prima.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add thread/opengl_thread.py
+git commit -m "Open the OpenGL window as borderless windowed instead of exclusive fullscreen"
+```
+
+---
+
+### Task 3: Upload video asincrono via PBO double-buffered (+ hoist `glPixelStorei`)
+
+Il fix dei 165fps col video: rimuove lo stallo sincrono di `glTexSubImage2D` da puntatore client usando 2 PBO in ring (copia CPU→PBO + DMA PBO→texture asincrone).
+
+**Files:**
+- Modify: `thread/opengl_thread.py` (`__init__` dopo `:603`; `run()` dopo `:1520`; `_upload_video_frame` `:1775-1804`; `_cleanup_gl` dopo `:1219`)
+
+**Interfaces:**
+- Consumes: `self._video_texture`, `self._video_tex_size`, `frame: np.ndarray` (HxWx3 uint8 RGB), `ctypes` (già importato), `FrameTimeStats` del Task 1 per la verifica.
+- Produces: nuovi attributi di stato `self._video_pbos: list | None`, `self._video_pbo_index: int`, `self._video_pbo_size: int` (consumati solo internamente da `_upload_video_frame`/`_cleanup_gl`).
+
+- [ ] **Step 1: Aggiungi gli attributi di stato dei PBO in `__init__`**
+
+In `__init__`, subito dopo la riga 603 (`self._video_time_acc = 0.0 ...`), aggiungi:
+
+```python
+        self._video_pbos = None             # 2 PBO (ping-pong) per upload async; None = non creati
+        self._video_pbo_index = 0           # indice del PBO corrente nel ring
+        self._video_pbo_size = 0            # byte allocati per ciascun PBO; 0 = non allocati
+```
+
+- [ ] **Step 2: Hoist di `glPixelStorei` nel `run()` (una volta sola)**
+
+In `run()`, subito dopo `glClearColor(0.0, 0.0, 0.0, 1.0)` (riga ~1520), aggiungi:
+
+```python
+            # RGB a 3 byte/pixel con larghezza non multipla di 4: forziamo una volta
+            # per tutte l'allineamento di unpack a 1 byte (lo usa l'upload video via
+            # PBO; sicuro anche per le texture RGBA, sempre 4-allineate).
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+```
+
+- [ ] **Step 3: Riscrivi `_upload_video_frame` per usare i PBO**
+
+Sostituisci l'intero metodo `_upload_video_frame` (righe ~1775-1804) con:
+
+```python
+    def _upload_video_frame(self, frame: np.ndarray) -> None:
+        """
+        Carica un frame video (np.ndarray HxWx3 uint8 RGB, riga 0 in alto) nella
+        texture video tramite PBO double-buffered: la copia CPU→PBO e il
+        trasferimento PBO→texture (DMA) sono asincroni, così l'upload NON stalla il
+        thread GL (a differenza di glTexSubImage2D da puntatore client). Alloca al
+        primo frame o quando cambiano le dimensioni. Il flip verticale è demandato
+        allo shader (uFlipV=1), non copiato in CPU. glPixelStorei(UNPACK_ALIGNMENT,1)
+        è impostato una volta in run().
+        """
+        h, w = int(frame.shape[0]), int(frame.shape[1])
+        size = w * h * 3  # RGB, 3 byte/pixel
+        frame = np.ascontiguousarray(frame)  # il PBO copia memoria contigua
+
+        # Crea (lazy) la texture al primo frame.
+        if self._video_texture is None:
+            self._video_texture = glGenTextures(1)
+            glBindTexture(GL_TEXTURE_2D, self._video_texture)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+            self._video_tex_size = None
+
+        # Crea (lazy) i 2 PBO del ring.
+        if self._video_pbos is None:
+            self._video_pbos = list(glGenBuffers(2))
+            self._video_pbo_index = 0
+            self._video_pbo_size = 0
+
+        # (Ri)alloca la texture al primo frame o al cambio dimensione (storage vuoto).
+        if self._video_tex_size != (w, h):
+            glBindTexture(GL_TEXTURE_2D, self._video_texture)
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB,
+                         GL_UNSIGNED_BYTE, None)
+            self._video_tex_size = (w, h)
+
+        # (Ri)alloca i PBO al cambio dimensione.
+        if self._video_pbo_size != size:
+            for pbo in self._video_pbos:
+                glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo)
+                glBufferData(GL_PIXEL_UNPACK_BUFFER, size, None, GL_STREAM_DRAW)
+            self._video_pbo_size = size
+
+        idx = self._video_pbo_index
+
+        # 1) Copia CPU → PBO[idx]: orphaning (storage fresco → niente attesa sulla
+        #    DMA del frame precedente) + scrittura dei byte del frame.
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, self._video_pbos[idx])
+        glBufferData(GL_PIXEL_UNPACK_BUFFER, size, None, GL_STREAM_DRAW)
+        glBufferSubData(GL_PIXEL_UNPACK_BUFFER, 0, size, frame)
+
+        # 2) PBO[idx] → texture: glTexSubImage2D legge dal PBO bound e ritorna subito
+        #    (DMA asincrona). NB: con un PBO bound l'ultimo argomento è un OFFSET nel
+        #    buffer, non un puntatore client → ctypes.c_void_p(0).
+        glBindTexture(GL_TEXTURE_2D, self._video_texture)
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGB,
+                        GL_UNSIGNED_BYTE, ctypes.c_void_p(0))
+
+        # 3) Sbinda il PBO: indispensabile, altrimenti la successiva glTexImage2D/
+        #    glTexSubImage2D dell'immagine di sfondo interpreterebbe il suo puntatore
+        #    come offset in questo PBO.
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0)
+
+        # Alterna i due PBO: il frame N+1 usa l'altro buffer, così la copia CPU non
+        # aspetta la DMA del frame N.
+        self._video_pbo_index = 1 - idx
+```
+
+- [ ] **Step 4: Libera i PBO in `_cleanup_gl`**
+
+In `_cleanup_gl`, subito dopo il blocco che libera `self._video_texture` (righe ~1217-1219), aggiungi:
+
+```python
+        if self._video_pbos:
+            _safe(lambda: glDeleteBuffers(len(self._video_pbos), self._video_pbos))
+            self._video_pbos = None
+            self._video_pbo_size = 0
+```
+
+- [ ] **Step 5: Smoke di import headless**
+
+Run: `uv run python -c "import thread.opengl_thread; print('import OK')"`
+Expected: `import OK` senza traceback.
+
+- [ ] **Step 6: Verifica manuale + misura (MANUALE — utente, Windows, `PERF_LOGS = True`)**
+
+Avvia `uv run python main.py`, apri il fullscreen **con video di sfondo** e confronta con la baseline:
+- il video si vede correttamente (orientamento giusto, niente righe sfalsate/colori storti su larghezze non multiple di 4);
+- `[PERF]` mostra `avg` **sotto** il budget e gli `~fps medi` risaliti a **~165**, `oltre-budget%` crollato vs baseline;
+- **switch immagine ↔ video** a runtime (via GUI): entrambi gli sfondi si caricano correttamente (verifica che il rebind del PBO a 0 non abbia rotto l'upload dell'immagine);
+- nessun glitch al **cambio di video** di dimensione diversa (riallocazione PBO/texture);
+- chiusura pulita (niente errori GL allo stop).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add thread/opengl_thread.py
+git commit -m "Upload video frames via double-buffered PBO to avoid GL-thread stalls"
+```
+
+---
+
+### Task 4: Verifica d'integrazione, documentazione e decisione di escalation
+
+Chiude il lavoro: regressione cross-modalità, aggiornamento doc locale, e il gate che decide se serve l'escalation (UBO/4.x) — che resta **fuori** da questo piano.
+
+**Files:**
+- Modify: `CLAUDE.md` (locale, **NON committato**)
+
+- [ ] **Step 1: Regressione manuale cross-modalità (MANUALE — utente, Windows)**
+
+Con il fullscreen attivo, scorri tutte le combinazioni e verifica che nulla sia regredito rispetto a prima del lavoro:
+- modalità **Barre / Radiale / Oscilloscopio / Linea** (con e senza ordine simmetrico);
+- effetti **peak-cap / bloom / beat** on/off;
+- sfondo **immagine** e **video**;
+- cambio **numero di bande** a runtime;
+- con `PERF_LOGS = True`: in ogni combinazione gli fps medi restano ~165 (il video non fa più scendere a 140-150).
+
+- [ ] **Step 2: Aggiorna `CLAUDE.md` (locale, non committato)**
+
+Nella sezione "OpenGL-specific concerns" / "Video background" documenta in una frase ciascuno:
+- la finestra è ora **borderless windowed** (no fullscreen esclusivo): creata `monitor=None` + `DECORATED=FALSE` + `set_window_pos` sul monitor scelto;
+- l'upload del frame video usa **PBO double-buffered** in `_upload_video_frame` (async, niente stallo); `glPixelStorei(GL_UNPACK_ALIGNMENT,1)` è hoisted in `run()`; PBO liberati in `_cleanup_gl`;
+- sotto `PERF_LOGS` il frame time è riassunto da `FrameTimeStats` (`thread/frame_time_stats.py`).
+
+**Non eseguire `git add CLAUDE.md`** (gitignored, vedi memoria `claude-md-untracked`).
+
+- [ ] **Step 3: Rimetti `PERF_LOGS = False` (se era stato messo a True per le misure)**
+
+Verifica che la riga 25 di `thread/opengl_thread.py` sia `PERF_LOGS = False`. Se l'hai cambiata per misurare, riportala a `False` e includila nell'ultimo commit se necessario:
+
+Run: `uv run python -c "import thread.opengl_thread as o; print('PERF_LOGS =', o.PERF_LOGS)"`
+Expected: `PERF_LOGS = False`
+
+- [ ] **Step 4: Decisione di escalation (gate)**
+
+Sulla base delle misure del Task 3/Step 1:
+- **Se i 165fps col video sono stabili** (`oltre-budget≈0%`): **chiudi qui.** Gli interventi del piano bastano.
+- **Se il thread GL è ancora CPU-bound** (avg vicino al budget anche senza video, o `oltre-budget%` non trascurabile): apri lo **Step 1 dell'escalation** dallo spec (UBO + skip uniform ridondanti, ancora su 3.3) come **nuovo** spec/piano dedicato. Il 4.x (persistent-mapped/DSA) e il DSP off-thread restano l'ultima risorsa, solo se la misura lo impone. **Non** sono parte di questo piano.
+
+---
+
+## Note di scope
+
+- **Preallocazione scratch numpy (intervento C dello spec):** valutata e **rinviata**. L'unica preallocazione "pulita" sarebbe sui path osc/line `build_*`, ma cambierebbe la firma dei builder (non pulita) e quei path **non** sono il collo di bottiglia riportato (barre + video). Coerente col qualificatore dello spec "solo dove è pulito" e col principio "misura prima": se la misura lo richiede, rientra nell'escalation. Gli altri due item dell'intervento C — hoist `glPixelStorei` (Task 3) e `PERF_LOGS` aggregato (Task 1) — sono implementati.
+- **Escalation (UBO, GL 4.x, DSP off-thread):** fuori da questo piano per design; gated sulla misura (Task 4/Step 4).
+
+## Self-Review
+
+**1. Copertura spec:**
+- Obiettivo "165fps col video" → Task 3 (PBO) + verifica misurata Task 3/Step 6. ✓
+- Obiettivo "borderless windowed" → Task 2. ✓
+- Obiettivo "margine frame time misurato prima/dopo" → Task 1 (`FrameTimeStats`) + checkpoint baseline + Task 3/Step 6. ✓
+- "Resta GL 3.3" → vincolo globale; PBO/map-range sono ≤3.0. ✓
+- Intervento C: hoist `glPixelStorei` (Task 3/Step 2) ✓, `PERF_LOGS` aggregato (Task 1) ✓, prealloc → rinviata con motivazione (Note di scope) ✓.
+- Edge case "rebind PBO a 0" → Task 3/Step 3 (commento + codice) + verifica switch immagine↔video Task 3/Step 6. ✓
+- Tier di escalation → Task 4/Step 4 + Note di scope. ✓
+- Verifica cross-modalità → Task 4/Step 1. ✓
+- Doc CLAUDE.md locale non committata → Task 4/Step 2. ✓
+
+**2. Scansione placeholder:** nessun TBD/TODO; ogni step ha codice/comando completo. ✓
+
+**3. Consistenza dei tipi:** `FrameTimeStats(report_every, budget_s)` e `add(dt) -> str | None` usati in modo identico in helper, test e cablaggio (Task 1/Step 6-7). Attributi `_video_pbos`/`_video_pbo_index`/`_video_pbo_size` definiti in `__init__` (Task 3/Step 1) e usati con gli stessi nomi in `_upload_video_frame` e `_cleanup_gl`. ✓

--- a/docs/superpowers/specs/2026-06-18-performance-windowing-opengl-design.md
+++ b/docs/superpowers/specs/2026-06-18-performance-windowing-opengl-design.md
@@ -1,0 +1,177 @@
+# Performance & windowing — renderer OpenGL
+
+**Data:** 2026-06-18
+**Stato:** design approvato, pronto per il piano di implementazione
+**Scope:** solo renderer fullscreen OpenGL (`thread/opengl_thread.py`); eventuale ritocco a
+`thread/video_decode_thread.py` solo se la misura lo richiede. Nessun cambio a GUI, code di
+controllo, algoritmo DSP o shader (output visivo invariato).
+
+## Contesto
+
+Dopo i blocchi feature (aspetto barre, effetti reattivi, modalità di visualizzazione) il focus si
+sposta sulle **performance** della finestra OpenGL. Osservazioni dell'utente su monitor 165Hz:
+
+- Senza video la GPU "dorme" (30-40% di utilizzo, clock ~300MHz): regge i 165fps con ampio margine.
+- Con il **video di sfondo** la GPU sale poco (~400MHz) ma gli fps **scendono a 140-150**: non
+  riesce più a tenere i 165.
+
+**Diagnosi (dalla lettura del codice).** La bassa occupazione GPU con VSync attivo
+(`glfw.swap_interval(1)`) è il comportamento *atteso e sano*: il carico (poche migliaia di quad in
+instanced rendering) è banale, la GPU lo finisce in molto meno di 6ms e si addormenta fino al
+vblank. **Il collo di bottiglia non è la GPU ma la CPU/Python sul thread GL**: a 165Hz ci sono ~6ms
+a frame, spesi in drain delle code, FFT+numpy, smoothing e decine di chiamate PyOpenGL (overhead
+per-chiamata). Col video si aggiungono (a) la contesa GIL del thread di decodifica e — soprattutto —
+(b) l'**upload texture sincrono** `glTexSubImage2D` da puntatore client (`_upload_video_frame`), che
+stalla il thread GL finché il driver non ha consumato i ~6MB del frame. Questo sfora il budget di
+6ms → vblank persi → 140-150 invece di 165.
+
+Inoltre la finestra è creata in **fullscreen esclusivo** (`glfw.create_window(..., selected_monitor,
+None)`), non in borderless windowed.
+
+## Obiettivo (criteri di successo misurabili)
+
+1. **165fps stabili con il video di sfondo attivo**: frame time costante < 6.06ms, nessun vblank
+   perso (verificato con `PERF_LOGS`).
+2. **Finestra borderless windowed**: nessun cambio di modalità video, alt-tab istantaneo, copre il
+   monitor selezionato.
+3. **Margine di frame time sul thread GL** documentato con misura `PERF_LOGS` prima/dopo.
+4. **Resta GL 3.3 core**, zero regressioni visive in ogni modalità/effetto, nessun taglio di
+   compatibilità hardware.
+
+## Principi guida
+
+1. **Misura prima di scalare.** Gli interventi del *core* (sotto) sono noti, isolati e a basso
+   rischio. Tecniche più invasive (UBO, GL 4.x, DSP off-thread) si fanno **solo se** `PERF_LOGS`
+   mostra il thread GL ancora CPU-bound dopo il core.
+2. **Interventi indipendenti e revertibili.** Borderless, upload async e limatura CPU sono
+   ortogonali: ciascuno si verifica e si annulla da solo.
+3. **Nessuna regressione percepita.** Output visivo, modalità, effetti e semantica dei messaggi di
+   controllo restano identici. Si cambia *come* si rende, non *cosa*.
+
+## Non-goal
+
+- **Nessun uso della GPU "libera" per qualità** (no supersampling/SSAA, no MSAA più alto, no più
+  barre, no effetti più pesanti): è una leva di qualità, non di performance, ed è fuori scope.
+- **Niente DSP off-thread** di default: l'FFT è ~0.1ms su 6ms e il GIL limita l'overlap reale;
+  spostarla non aiuta il budget. Solo se la misura lo smentisce.
+- **Niente GL 4.x né riscrittura a UBO nel core**: confinati al tier di escalation.
+- **Nessuna opzione fullscreen esclusivo** mantenuta accanto alla borderless: la borderless la
+  sostituisce (su Windows 10/11 la latenza è ~equivalente grazie a *independent flip*).
+- Nessun cambio a GUI, algoritmo DSP, shader, o semantica della control-queue.
+
+## Decisioni prese durante il brainstorming
+
+- **Profilo:** GL **3.3 + escalation su misura** (non rework profondo a prescindere). Si prende ~tutto
+  il beneficio pratico restando su 3.3; il 4.x solo se i numeri lo impongono.
+- **Borderless** sostituisce il fullscreen esclusivo (rispetta il selettore monitor esistente).
+- **Fix dei 165fps col video** = upload asincrono via **PBO** (core da GL 2.1, nessun bump di
+  versione).
+- **UBO / skip-uniform-ridondanti** spostati dal core al **tier di escalation** (riscrivere le
+  uniform di tutti gli shader è ampio e a ROI basso → non si fa a tappeto).
+
+## Design
+
+### A. Borderless windowed
+
+In `run()`, sostituire la creazione della finestra fullscreen esclusiva con una finestra **windowed
+senza decorazioni** dimensionata e posizionata sul monitor selezionato:
+
+- Mantenere gli hint di contesto attuali (3.3 core, forward-compat) e `glfw.SAMPLES = MSAA_SAMPLES`.
+- Aggiungere `glfw.window_hint(glfw.DECORATED, glfw.FALSE)` (niente bordo/titolo). Opzionale
+  `glfw.window_hint(glfw.FLOATING, glfw.TRUE)` per tenerla sopra.
+- Risolvere il monitor come ora; leggere `video_mode` (risoluzione + refresh) **e** la posizione del
+  monitor con `glfw.get_monitor_pos(selected_monitor)`.
+- Creare la finestra **windowed**: `glfw.create_window(w, h, "Audio Visualizer", None, None)`, poi
+  `glfw.set_window_pos(window, mon_x, mon_y)` così copre esattamente il monitor.
+- Restano invariati: `swap_interval(1)`, viewport dal framebuffer reale, ESC/key callback,
+  `glViewport`.
+
+**Comportamento atteso.** Windows 10/11: finestra borderless a tutto schermo → DWM concede
+*independent flip* → latenza ~pari all'esclusivo, niente tearing, alt-tab istantaneo (niente cambio
+di modalità video). **Caveat Linux:** il bypass del compositor dipende dal WM (X11/Wayland);
+accettabile per un visualizer.
+
+### B. Upload video asincrono — PBO double-buffered  ← fix dei 165fps
+
+Sostituire l'upload sincrono in `_upload_video_frame` con **2 Pixel Buffer Object in ring**:
+
+1. Allocare 2 PBO (`glGenBuffers(2)`) e un indice corrente; (ri)allocarli a
+   `width*height*3` byte al primo frame o al cambio dimensione, insieme alla texture
+   (`glTexImage2D(... NULL)`).
+2. Ogni frame, con PBO[idx] legato a `GL_PIXEL_UNPACK_BUFFER`:
+   - **orphaning**: `glBufferData(GL_PIXEL_UNPACK_BUFFER, size, None, GL_STREAM_DRAW)` (il driver
+     restituisce storage fresco → nessun fence manuale, nessuna attesa sul buffer in uso dalla GPU);
+   - copiare i byte del frame nel PBO (`glBufferSubData`; in alternativa `glMapBufferRange` con
+     `GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT | GL_MAP_UNSYNCHRONIZED_BIT` + memcpy, se la
+     misura lo giustifica);
+   - `glTexSubImage2D(..., GL_RGB, GL_UNSIGNED_BYTE, ctypes.c_void_p(0))` → legge **dal PBO** e
+     ritorna subito (trasferimento DMA asincrono, **niente stallo** del thread GL).
+3. Sbindare il PBO (`bind 0`) e avanzare l'indice (frame N+1 usa l'altro PBO → la copia CPU non
+   aspetta la DMA del frame N).
+
+Dettagli: `glPixelStorei(GL_UNPACK_ALIGNMENT, 1)` impostato **una volta** (vedi C), non per-frame; il
+flip verticale resta sullo shader (`uFlipV`). PBO liberati in `_cleanup_gl`. Tutto **3.3-safe** (PBO
+core da 2.1, map-range da 3.0). Il rischio di corruzione è basso grazie all'orphaning (niente
+sincronizzazione manuale).
+
+### C. Limatura CPU (basso rischio) + strumentazione di misura
+
+- **Hoist** di `glPixelStorei(GL_UNPACK_ALIGNMENT, 1)` e di ogni stato GL invariante fuori dal loop
+  (in init / a contesto creato).
+- **Preallocazione** degli scratch per-frame **solo dove è pulito** (path osc/line `build_*`); nel
+  core FFT le allocazioni sono già piccole e in parte con `out=` → guadagno modesto, niente
+  riscritture rischiose.
+- **`PERF_LOGS` aggregato**: invece dello spam per-frame, statistiche su finestra di N frame
+  (avg/min/max frame time, % di frame sopra il budget di 6.06ms), così il confronto prima/dopo è
+  leggibile. È il **gate** che decide se serve l'escalation.
+
+### D. Tier di escalation — *solo se la misura lo impone*
+
+Si procede a uno step solo se `PERF_LOGS` mostra il thread GL ancora CPU-bound dopo il tier
+precedente.
+
+- **Step 1 (resta 3.3):** UBO per batchare le uniform; skip degli upload-uniform ridondanti
+  (impostarle solo al cambio valore).
+- **Step 2 (richiede 4.x):** buffer **persistent-mapped** (`GL_ARB_buffer_storage`, 4.4) per
+  heights/strip/PBO; eventuale **DSA** (4.5) per pulizia. Comporta bump della versione minima del
+  contesto + fencing manuale → da fare consapevolmente.
+- **DSP off-thread:** solo se il DSP risulta un costo reale (improbabile).
+
+## Errori / edge case
+
+- **Borderless cross-platform:** Windows → independent flip; Linux → dipende dal compositor.
+  Verifica su entrambi se possibile; il fallback peggiore (composito attivo) resta giocabile.
+- **PBO:** allocazione/riallocazione al primo frame o al cambio dimensione del video; `bind 0` dopo
+  l'uso per non lasciare il `GL_PIXEL_UNPACK_BUFFER` legato (altre `glTexImage2D`/`glTexSubImage2D`
+  — sfondo immagine — interpreterebbero il puntatore come offset nel PBO). Risorse liberate in
+  `_cleanup_gl`; `_stop_video`/`clear_video` smettono di caricare ma non devono lasciare stato GL
+  incoerente.
+- **Nessuna test suite** (CLAUDE.md) → ogni cambiamento va verificato eseguendo l'app; gli interventi
+  sono piccoli e indipendenti per limitare il raggio di una regressione.
+
+## Verifica
+
+Nessuna test suite: si verifica eseguendo l'app + `PERF_LOGS`.
+
+- **Headless (WSL2, `.venv-linux`):** smoke test EGL che l'import OpenGL/creazione contesto regga; le
+  parti GL vere richiedono un display. *Vedi memorie `wsl2-venv-and-gl-verification` e
+  `soundcard-headless-argv`.*
+- **Windows (display reale, 165Hz) — la verifica che conta:**
+  - **Baseline:** `PERF_LOGS` con e senza video → registrare avg/min/max frame time e % frame sopra
+    budget (riproduce il 140-150 col video).
+  - **Dopo A:** borderless copre il monitor, alt-tab istantaneo, 165fps invariati **senza** video.
+  - **Dopo B:** col video il frame time torna < 6ms e gli fps risalgono a 165 stabili.
+  - **Non-regressione:** ogni modalità (Barre/Radiale/Oscilloscopio/Linea), effetti on/off, sfondo
+    immagine **e** video, cambio bande a runtime.
+- **Decisione escalation:** se dopo A+B+C la misura mostra ancora il thread GL CPU-bound, aprire lo
+  Step 1; altrimenti chiudere qui.
+
+## File toccati (previsti)
+
+- `thread/opengl_thread.py` — `run()` (creazione finestra borderless: hint `DECORATED`, windowed +
+  `set_window_pos` sul monitor); `_upload_video_frame` (PBO double-buffered); hoist `glPixelStorei` e
+  init dei PBO; `_cleanup_gl` (free PBO); eventuale `PERF_LOGS` aggregato nel loop.
+- `thread/video_decode_thread.py` — **non previsto**; candidato solo se la misura mostra contesa/
+  back-pressure da rivedere.
+- `CLAUDE.md` — documentare borderless + path PBO video (file locale, **gitignored** in questo repo:
+  aggiornato ma non committato — vedi memoria `claude-md-untracked`).

--- a/tests/test_frame_time_stats.py
+++ b/tests/test_frame_time_stats.py
@@ -1,0 +1,52 @@
+"""
+Verifica headless (niente pytest nel repo): asserzioni pure su FrameTimeStats.
+Eseguire dalla radice del repo con:  uv run python tests/test_frame_time_stats.py
+Uscita 0 + "OK" = passato.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from thread.frame_time_stats import FrameTimeStats
+
+
+def test_no_report_before_window():
+    stats = FrameTimeStats(report_every=4, budget_s=0.01)
+    assert stats.add(0.005) is None
+    assert stats.add(0.005) is None
+    assert stats.add(0.005) is None
+
+
+def test_report_at_window_boundary():
+    stats = FrameTimeStats(report_every=4, budget_s=0.01)
+    stats.add(0.005)
+    stats.add(0.005)
+    stats.add(0.015)  # oltre budget
+    report = stats.add(0.005)
+    assert report is not None, "il 4° frame deve produrre un report"
+    # avg = (0.005+0.005+0.015+0.005)/4 = 0.0075 s = 7.50 ms
+    assert "avg=7.50ms" in report, report
+    assert "min=5.00ms" in report, report
+    assert "max=15.00ms" in report, report
+    # 1 frame su 4 oltre budget = 25%
+    assert "oltre-budget=25%" in report, report
+
+
+def test_resets_after_report():
+    stats = FrameTimeStats(report_every=2, budget_s=0.01)
+    assert stats.add(0.005) is None
+    assert stats.add(0.005) is not None   # primo report
+    assert stats.add(0.005) is None       # finestra azzerata
+    assert stats.add(0.005) is not None   # secondo report
+
+
+def main():
+    test_no_report_before_window()
+    test_report_at_window_boundary()
+    test_resets_after_report()
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_frame_time_stats.py
+++ b/tests/test_frame_time_stats.py
@@ -18,19 +18,21 @@ def test_no_report_before_window():
     assert stats.add(0.005) is None
 
 
-def test_report_at_window_boundary():
-    stats = FrameTimeStats(report_every=4, budget_s=0.01)
+def test_report_format_median_max_lag():
+    stats = FrameTimeStats(report_every=4, budget_s=0.01)  # soglia lag = 0.015 s
     stats.add(0.005)
     stats.add(0.005)
-    stats.add(0.015)  # oltre budget
+    stats.add(0.020)  # lag spike (> 15 ms)
     report = stats.add(0.005)
     assert report is not None, "il 4° frame deve produrre un report"
-    # avg = (0.005+0.005+0.015+0.005)/4 = 0.0075 s = 7.50 ms
-    assert "avg=7.50ms" in report, report
-    assert "min=5.00ms" in report, report
-    assert "max=15.00ms" in report, report
-    # 1 frame su 4 oltre budget = 25%
-    assert "oltre-budget=25%" in report, report
+    # ordinati [5,5,5,20] ms → mediana = 5.00 ms, max = 20.00 ms, media = 8.75 ms
+    assert "median=5.00ms" in report, report
+    assert "avg=8.75ms" in report, report
+    assert "max=20.00ms" in report, report
+    # soglia lag = budget*1.5 = 15.0 ms; 1 frame oltre
+    assert "lag-spikes(>15.0ms)=1" in report, report
+    # gli fps sono calcolati dalla MEDIANA (robusta agli outlier): 1/0.005 = 200
+    assert "~200fps mediani" in report, report
 
 
 def test_resets_after_report():
@@ -43,7 +45,7 @@ def test_resets_after_report():
 
 def main():
     test_no_report_before_window()
-    test_report_at_window_boundary()
+    test_report_format_median_max_lag()
     test_resets_after_report()
     print("OK")
 

--- a/thread/frame_time_stats.py
+++ b/thread/frame_time_stats.py
@@ -3,32 +3,31 @@ Statistiche aggregate sul frame time per la diagnosi di performance del renderer
 OpenGL. Puro Python, nessuna dipendenza GL → importabile e verificabile headless.
 
 Accumula i delta-tempo dei frame e, ogni `report_every` frame, produce una riga
-di riepilogo (avg/min/max + percentuale di frame oltre il budget) usata sotto il
-flag PERF_LOGS per confrontare le performance prima/dopo un intervento.
+di riepilogo usata sotto il flag PERF_LOGS per confrontare le performance. Riporta
+la MEDIANA (robusta agli outlier, a differenza della media — un singolo hitch non
+falsa il numero), il massimo (cattura gli hitch) e il numero di "lag spike": frame
+il cui tempo supera `lag_factor`× il budget di refresh, così la normale jitter del
+VSync attorno all'intervallo di refresh non viene contata come problema.
 """
 from __future__ import annotations
 
 
 class FrameTimeStats:
-    def __init__(self, report_every: int = 120, budget_s: float = 1.0 / 60.0) -> None:
+    def __init__(self, report_every: int = 120, budget_s: float = 1.0 / 60.0,
+                 lag_factor: float = 1.5) -> None:
         """
         Args:
             report_every: numero di frame per ogni riga di riepilogo (>= 1).
-            budget_s: budget di frame time in secondi; i frame più lenti di questo
-                contano come "oltre budget" (tipicamente 1/refresh_rate).
+            budget_s: budget di frame time in secondi (tipicamente 1/refresh_rate).
+            lag_factor: un frame conta come "lag spike" se supera lag_factor*budget_s
+                (default 1.5×: ignora la jitter del VSync, segna i veri hitch).
         """
         if report_every < 1:
             raise ValueError("report_every must be >= 1")
         self._report_every = int(report_every)
         self._budget_s = float(budget_s)
-        self._reset()
-
-    def _reset(self) -> None:
-        self._count = 0
-        self._sum = 0.0
-        self._min = float("inf")
-        self._max = 0.0
-        self._over_budget = 0
+        self._lag_threshold = float(budget_s) * float(lag_factor)
+        self._samples: list[float] = []
 
     def add(self, dt: float) -> str | None:
         """
@@ -36,29 +35,24 @@ class FrameTimeStats:
         riepilogo ogni `report_every` frame (e poi azzera la finestra), altrimenti
         None.
         """
-        self._count += 1
-        self._sum += dt
-        if dt < self._min:
-            self._min = dt
-        if dt > self._max:
-            self._max = dt
-        if dt > self._budget_s:
-            self._over_budget += 1
-
-        if self._count < self._report_every:
+        self._samples.append(dt)
+        if len(self._samples) < self._report_every:
             return None
-
         report = self._format()
-        self._reset()
+        self._samples = []
         return report
 
     def _format(self) -> str:
-        avg = self._sum / self._count
-        over_pct = 100.0 * self._over_budget / self._count
-        avg_fps = 1.0 / avg if avg > 0 else 0.0
+        s = sorted(self._samples)
+        n = len(s)
+        median = s[n // 2] if n % 2 else 0.5 * (s[n // 2 - 1] + s[n // 2])
+        avg = sum(s) / n
+        mx = s[-1]
+        lag = sum(1 for x in s if x > self._lag_threshold)
+        median_fps = 1.0 / median if median > 0 else 0.0
         return (
-            f"[PERF] {self._count} frame: "
-            f"avg={avg * 1e3:.2f}ms min={self._min * 1e3:.2f}ms max={self._max * 1e3:.2f}ms "
-            f"oltre-budget={over_pct:.0f}% "
-            f"(budget={self._budget_s * 1e3:.2f}ms, ~{avg_fps:.0f}fps medi)"
+            f"[PERF] {n} frame: "
+            f"median={median * 1e3:.2f}ms avg={avg * 1e3:.2f}ms max={mx * 1e3:.2f}ms "
+            f"lag-spikes(>{self._lag_threshold * 1e3:.1f}ms)={lag} "
+            f"(~{median_fps:.0f}fps mediani)"
         )

--- a/thread/frame_time_stats.py
+++ b/thread/frame_time_stats.py
@@ -1,0 +1,64 @@
+"""
+Statistiche aggregate sul frame time per la diagnosi di performance del renderer
+OpenGL. Puro Python, nessuna dipendenza GL → importabile e verificabile headless.
+
+Accumula i delta-tempo dei frame e, ogni `report_every` frame, produce una riga
+di riepilogo (avg/min/max + percentuale di frame oltre il budget) usata sotto il
+flag PERF_LOGS per confrontare le performance prima/dopo un intervento.
+"""
+from __future__ import annotations
+
+
+class FrameTimeStats:
+    def __init__(self, report_every: int = 120, budget_s: float = 1.0 / 60.0) -> None:
+        """
+        Args:
+            report_every: numero di frame per ogni riga di riepilogo (>= 1).
+            budget_s: budget di frame time in secondi; i frame più lenti di questo
+                contano come "oltre budget" (tipicamente 1/refresh_rate).
+        """
+        if report_every < 1:
+            raise ValueError("report_every must be >= 1")
+        self._report_every = int(report_every)
+        self._budget_s = float(budget_s)
+        self._reset()
+
+    def _reset(self) -> None:
+        self._count = 0
+        self._sum = 0.0
+        self._min = float("inf")
+        self._max = 0.0
+        self._over_budget = 0
+
+    def add(self, dt: float) -> str | None:
+        """
+        Accumula un delta-tempo di frame (secondi). Ritorna una stringa di
+        riepilogo ogni `report_every` frame (e poi azzera la finestra), altrimenti
+        None.
+        """
+        self._count += 1
+        self._sum += dt
+        if dt < self._min:
+            self._min = dt
+        if dt > self._max:
+            self._max = dt
+        if dt > self._budget_s:
+            self._over_budget += 1
+
+        if self._count < self._report_every:
+            return None
+
+        report = self._format()
+        self._reset()
+        return report
+
+    def _format(self) -> str:
+        avg = self._sum / self._count
+        over_pct = 100.0 * self._over_budget / self._count
+        avg_fps = 1.0 / avg if avg > 0 else 0.0
+        return (
+            f"[PERF] {self._count} frame: "
+            f"avg={avg * 1e3:.2f}ms min={self._min * 1e3:.2f}ms max={self._max * 1e3:.2f}ms "
+            f"oltre-budget={over_pct:.0f}% "
+            f"(budget={self._budget_s * 1e3:.2f}ms, ~{avg_fps:.0f}fps medi)"
+        )

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -14,6 +14,7 @@ from PIL.Image import Transpose
 
 from thread.AudioBufferAccumulator import AudioBufferAccumulator
 from thread.video_decode_thread import VideoDecodeThread
+from thread.frame_time_stats import FrameTimeStats
 
 RATE = 44100
 N_FFT = 4096
@@ -1539,6 +1540,10 @@ class EqualizerOpenGLThread(threading.Thread):
             # Timing preciso
             last_frame_time = glfw.get_time()
 
+            # Statistiche aggregate del frame time (solo sotto PERF_LOGS): budget
+            # = 1/refresh del monitor → "oltre-budget" conta i frame che mancano il vblank.
+            frame_stats = FrameTimeStats(report_every=120, budget_s=1.0 / max(self.frame_rate, 1)) if PERF_LOGS else None
+
             # -------------------------
             # MAIN LOOP
             # -------------------------
@@ -1605,9 +1610,10 @@ class EqualizerOpenGLThread(threading.Thread):
                 glfw.swap_buffers(window)
                 glfw.poll_events()
 
-                if PERF_LOGS and frame_delta > 0:
-                    fps = 1.0 / frame_delta
-                    print(f"PERF LOG: FrameTime = {frame_delta * 1000:.3f}ms (FPS ~ {fps:.1f})")
+                if frame_stats is not None and frame_delta > 0:
+                    report = frame_stats.add(frame_delta)
+                    if report:
+                        print(report)
         except Exception as exc:
             # Errore non gestito: notifica la GUI affinché ripristini lo stato
             # (equalizer_opengl_thread = None) invece di lasciare un thread morto.

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -1494,10 +1494,23 @@ class EqualizerOpenGLThread(threading.Thread):
             glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, glfw.TRUE)
             # MSAA: richiedi un framebuffer di default multisample (antialiasing hardware).
             glfw.window_hint(glfw.SAMPLES, MSAA_SAMPLES)
+            # Borderless windowed (NON fullscreen esclusivo): finestra senza bordo/titolo,
+            # dimensionata e posizionata sul monitor scelto. Niente cambio di modalità video
+            # → alt-tab istantaneo e (su Windows) present al refresh del monitor senza il
+            # mode-switch dell'esclusivo. NON FLOATING: come le borderless dei giochi
+            # moderni, l'alt-tab la manda dietro.
+            glfw.window_hint(glfw.DECORATED, glfw.FALSE)
 
-            window = glfw.create_window(self.window_width, self.window_height, "Audio Visualizer", selected_monitor, None)
+            # Posizione del monitor scelto nello spazio virtuale multi-monitor.
+            monitor_x, monitor_y = glfw.get_monitor_pos(selected_monitor)
+
+            # Finestra WINDOWED (monitor=None): è la borderless, non l'esclusiva.
+            window = glfw.create_window(self.window_width, self.window_height, "Audio Visualizer", None, None)
             if not window:
                 raise Exception("GLFW window creation failed")
+
+            # Posizionala esattamente sul monitor scelto così lo copre tutto.
+            glfw.set_window_pos(window, monitor_x, monitor_y)
 
             # check if the stop event is set
             if self.stop_event.is_set():

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -602,6 +602,9 @@ class EqualizerOpenGLThread(threading.Thread):
         self._video_tex_size = None         # (w, h) texture allocata; None = non ancora creata
         self._video_frame_interval = 1.0 / 30.0  # 1/fps (aggiornato dai metadati del video)
         self._video_time_acc = 0.0          # accumulatore di tempo per il pacing del video
+        self._video_pbos = None             # 2 PBO (ping-pong) per upload async; None = non creati
+        self._video_pbo_index = 0           # indice del PBO corrente nel ring
+        self._video_pbo_size = 0            # byte allocati per ciascun PBO; 0 = non allocati
 
         self.window_width = self.window_height = None
         self.frame_rate = None
@@ -1218,6 +1221,10 @@ class EqualizerOpenGLThread(threading.Thread):
         if self._video_texture:
             _safe(lambda: glDeleteTextures(1, [self._video_texture]))
             self._video_texture = None
+        if self._video_pbos:
+            _safe(lambda: glDeleteBuffers(len(self._video_pbos), self._video_pbos))
+            self._video_pbos = None
+            self._video_pbo_size = 0
         for tex in self._bloom_texs:
             _safe(lambda t=tex: glDeleteTextures(1, [t]))
         for fbo in self._bloom_fbos:
@@ -1533,6 +1540,11 @@ class EqualizerOpenGLThread(threading.Thread):
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
             glClearColor(0.0, 0.0, 0.0, 1.0)
 
+            # RGB a 3 byte/pixel con larghezza non multipla di 4: forziamo una volta
+            # per tutte l'allineamento di unpack a 1 byte (lo usa l'upload video via
+            # PBO; sicuro anche per le texture RGBA, sempre 4-allineate).
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+
             # Abilita l'MSAA (no-op se il driver non ha concesso il framebuffer multisample)
             glEnable(GL_MULTISAMPLE)
             if GENERAL_LOG:
@@ -1794,16 +1806,18 @@ class EqualizerOpenGLThread(threading.Thread):
     def _upload_video_frame(self, frame: np.ndarray) -> None:
         """
         Carica un frame video (np.ndarray HxWx3 uint8 RGB, riga 0 in alto) nella
-        texture video. Alloca con glTexImage2D al primo frame o quando cambiano le
-        dimensioni, poi aggiorna in-place con glTexSubImage2D (niente riallocazioni).
-        Il flip verticale è demandato allo shader (uFlipV=1), non copiato in CPU.
+        texture video tramite PBO double-buffered: la copia CPU→PBO e il
+        trasferimento PBO→texture (DMA) sono asincroni, così l'upload NON stalla il
+        thread GL (a differenza di glTexSubImage2D da puntatore client). Alloca al
+        primo frame o quando cambiano le dimensioni. Il flip verticale è demandato
+        allo shader (uFlipV=1), non copiato in CPU. glPixelStorei(UNPACK_ALIGNMENT,1)
+        è impostato una volta in run().
         """
         h, w = int(frame.shape[0]), int(frame.shape[1])
+        size = w * h * 3  # RGB, 3 byte/pixel
+        frame = np.ascontiguousarray(frame)  # il PBO copia memoria contigua
 
-        # Frame RGB a 3 byte/pixel: con larghezza non multipla di 4 l'allineamento
-        # di default (4) sfalserebbe le righe. Forziamo l'allineamento a 1 byte.
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
-
+        # Crea (lazy) la texture al primo frame.
         if self._video_texture is None:
             self._video_texture = glGenTextures(1)
             glBindTexture(GL_TEXTURE_2D, self._video_texture)
@@ -1813,14 +1827,49 @@ class EqualizerOpenGLThread(threading.Thread):
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
             self._video_tex_size = None
 
-        glBindTexture(GL_TEXTURE_2D, self._video_texture)
+        # Crea (lazy) i 2 PBO del ring.
+        if self._video_pbos is None:
+            self._video_pbos = list(glGenBuffers(2))
+            self._video_pbo_index = 0
+            self._video_pbo_size = 0
+
+        # (Ri)alloca la texture al primo frame o al cambio dimensione (storage vuoto).
         if self._video_tex_size != (w, h):
+            glBindTexture(GL_TEXTURE_2D, self._video_texture)
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB,
-                         GL_UNSIGNED_BYTE, frame)
+                         GL_UNSIGNED_BYTE, None)
             self._video_tex_size = (w, h)
-        else:
-            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGB,
-                            GL_UNSIGNED_BYTE, frame)
+
+        # (Ri)alloca i PBO al cambio dimensione.
+        if self._video_pbo_size != size:
+            for pbo in self._video_pbos:
+                glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo)
+                glBufferData(GL_PIXEL_UNPACK_BUFFER, size, None, GL_STREAM_DRAW)
+            self._video_pbo_size = size
+
+        idx = self._video_pbo_index
+
+        # 1) Copia CPU → PBO[idx]: orphaning (storage fresco → niente attesa sulla
+        #    DMA del frame precedente) + scrittura dei byte del frame.
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, self._video_pbos[idx])
+        glBufferData(GL_PIXEL_UNPACK_BUFFER, size, None, GL_STREAM_DRAW)
+        glBufferSubData(GL_PIXEL_UNPACK_BUFFER, 0, size, frame)
+
+        # 2) PBO[idx] → texture: glTexSubImage2D legge dal PBO bound e ritorna subito
+        #    (DMA asincrona). NB: con un PBO bound l'ultimo argomento è un OFFSET nel
+        #    buffer, non un puntatore client → ctypes.c_void_p(0).
+        glBindTexture(GL_TEXTURE_2D, self._video_texture)
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGB,
+                        GL_UNSIGNED_BYTE, ctypes.c_void_p(0))
+
+        # 3) Sbinda il PBO: indispensabile, altrimenti la successiva glTexImage2D/
+        #    glTexSubImage2D dell'immagine di sfondo interpreterebbe il suo puntatore
+        #    come offset in questo PBO.
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0)
+
+        # Alterna i due PBO: il frame N+1 usa l'altro buffer, così la copia CPU non
+        # aspetta la DMA del frame N.
+        self._video_pbo_index = 1 - idx
 
     # Il rendering è ora interamente in _render() (shader + instancing, core 3.3):
     # i vecchi draw_background/draw_bars (pipeline fixed-function) sono stati rimossi.

--- a/thread/opengl_thread.py
+++ b/thread/opengl_thread.py
@@ -23,7 +23,7 @@ MAX_FREQ = 20000
 
 GENERAL_LOG = False
 FFT_LOGS = False
-PERF_LOGS = False
+PERF_LOGS = True
 
 # --- Taratura fedeltà/latenza (regolabili a vista) ---
 # Scala dB assoluta: l'altezza barra riflette il livello reale del segnale.
@@ -1604,8 +1604,8 @@ class EqualizerOpenGLThread(threading.Thread):
                         noise_threshold=self._noise_threshold,
                         channels=self._channels
                     )
-                    if PERF_LOGS:
-                        print(f"PERF LOG: FFT took {(time.perf_counter() - t0) * 1000:.3f} ms")
+                    if FFT_LOGS:
+                        print(f"FFT LOG: FFT took {(time.perf_counter() - t0) * 1000:.3f} ms")
 
                 # Waveform mono per l'oscilloscopio (solo se serve): media dei canali.
                 waveform = None


### PR DESCRIPTION
## Summary
Performance & windowing pass on the fullscreen OpenGL renderer: stable framerate with a video background and a modern borderless window. Stays on GL 3.3 (no context-version bump).

## Changes
- **Borderless windowed**: the renderer now opens a borderless, undecorated window sized to the selected monitor (`monitor=None` + `GLFW_DECORATED=FALSE` + `set_window_pos`) instead of exclusive fullscreen — instant alt-tab, no video-mode switch.
- **Async video upload (PBO)**: video frames stream through 2 ping-pong PBOs (orphan + `glBufferSubData`, then `glTexSubImage2D` reads from the PBO via DMA) instead of a synchronous `glTexSubImage2D` from a client pointer. Removes the per-frame GL-thread stall that dropped fps when a video background was active. `glPixelStorei(GL_UNPACK_ALIGNMENT, 1)` hoisted to `run()`; PBOs freed in `_cleanup_gl`.
- **Frame-time instrumentation**: new pure `FrameTimeStats` helper (`thread/frame_time_stats.py`, unit-tested) prints an aggregated summary under `PERF_LOGS` — median (robust to outliers), max, and lag-spike count over 1.5x the refresh budget. Per-frame FFT timing moved to `FFT_LOGS`.

## Verification
No automated suite (per project). `FrameTimeStats` is unit-tested headless; the renderer was verified on Windows @165 Hz:
- Before: ~140-150 fps with a video background.
- After (heaviest config — radial + video + symmetric + gradient + glow + beat pulse): median pinned at 6.13 ms (~163 fps) across the whole capture, only occasional single dropped frames (~12 ms, beat/bloom bursts). The constant droop is gone.

Escalation (UBO / GL 4.x / DSP off-thread) evaluated and not needed — the GL thread is neither CPU-bound nor GPU-saturated.

Design & plan: `docs/superpowers/specs/2026-06-18-performance-windowing-opengl-design.md`, `docs/superpowers/plans/2026-06-18-performance-windowing-opengl.md`.